### PR TITLE
fix(ci): drop redundant anchore/sbom-action from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,12 +73,6 @@ jobs:
           for tag in $IMAGES; do
             cosign sign --yes "${tag}@${DIGEST}"
           done
-      - uses: anchore/sbom-action@v0
-        with:
-          image: ghcr.io/${{ github.repository_owner }}/alertly@${{ steps.build.outputs.digest }}
-          format: spdx-json
-          output-file: sbom.spdx.json
-          upload-release-assets: true
 
   detect-charts:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Changed
+- `release.yaml`: dropped the standalone `anchore/sbom-action` step. SBOM is already produced by `docker/build-push-action` (`sbom: true`) and attached to the image as an OCI attestation, so the extra step was redundant and was failing on syft exit code 1.
+
+## [0.0.1] - 2026-04-21
+
 ### Added
 - Initial project scaffolding: Alertmanager + Kubewatch sources, Telegram client with retry/rate-limit/splitting, `text/template` renderer, Prometheus metrics, `/healthz` + `/readyz`.
 - OSS scaffolding: CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, dependabot, issue/PR templates.
 - CI workflow (lint, test, build, trivy fs/image scan).
-- Release workflow (goreleaser binaries, multi-arch container image, cosign keyless signing, SBOM attestation).
+- Release workflow (goreleaser binaries, multi-arch container image `ghcr.io/maksimrudakov/alertly`, cosign keyless signing, SBOM attestation via build-push-action).
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/MaksimRudakov/alertly/releases/tag/v0.0.1


### PR DESCRIPTION
## Summary

`docker/build-push-action` with `sbom: true` already produces an SPDX SBOM and attaches it to the image manifest as an OCI attestation (verified on `ghcr.io/maksimrudakov/alertly:0.0.1`).

The extra `anchore/sbom-action` step tried to **also** publish the SBOM as a downloadable file in the GitHub Release. It failed on `syft` exit code 1 in the `v0.0.1` release, painting the `docker` job red even though everything load-bearing (image push + cosign sign) succeeded.

Drop the redundant step. SBOM stays available via the OCI attestation:
```bash
cosign download attestation \
  --predicate-type https://spdx.dev/Document \
  ghcr.io/maksimrudakov/alertly:0.0.1
```

## Type of change

- [x] CI / build

## Checklist

- [x] No code changes; lint/test N/A
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] No secrets, tokens, or PII in diff

## Test plan

- [ ] CI green on this PR
- [ ] Next release tag (`v0.0.2` or `v0.1.0`) — `docker` job should be fully green
- [ ] Verify SBOM attestation still attached on next release via `cosign download attestation`