### PR TITLE
feat: Helm chart (v0.0.1) + alertmanager template rework

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,3 +83,37 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: 1
           ignore-unfixed: true
+
+  chart-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: azure/setup-helm@v5
+        with:
+          version: v3.16.0
+      - name: helm lint
+        run: helm lint charts/alertly
+      - name: helm template (defaults)
+        run: |
+          helm template test charts/alertly \
+            --set secret.values.telegramBotToken=ci \
+            --set secret.values.webhookAuthToken=ci > /tmp/rendered.yaml
+      - name: helm template (ingress + reloader + extraManifests)
+        run: |
+          helm template test charts/alertly \
+            --set secret.values.telegramBotToken=ci \
+            --set secret.values.webhookAuthToken=ci \
+            --set ingress.enabled=true \
+            --set reloader.enabled=true > /tmp/rendered-full.yaml
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Install helm-docs
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+      - name: helm-docs check (charts/alertly/README.md must be up to date)
+        run: |
+          helm-docs --chart-search-root=charts
+          if ! git diff --exit-code charts/ ; then
+            echo "::error::charts/alertly/README.md is stale. Run 'helm-docs --chart-search-root=charts' locally and commit."
+            exit 1
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [docker, detect-charts]
     if: needs.detect-charts.outputs.has_charts == 'true'
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -110,18 +114,47 @@ jobs:
       - uses: azure/setup-helm@v5
         with:
           version: v3.16.0
+      - uses: sigstore/cosign-installer@v3
       - uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
           skip_existing: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push chart to OCI (ghcr.io)
+      - name: Sign chart tarballs (cosign keyless) and attach signatures to GitHub Release
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          helm registry login ghcr.io -u $GITHUB_ACTOR -p ${{ secrets.GITHUB_TOKEN }}
+          set -euo pipefail
           for chart in charts/*/; do
             name=$(basename "$chart")
             version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
+            tag="${name}-${version}"
+            tgz="/tmp/${tag}.tgz"
             helm package "$chart" -d /tmp
-            helm push "/tmp/${name}-${version}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+            cosign sign-blob --yes \
+              --output-signature "${tgz}.sig" \
+              --output-certificate "${tgz}.pem" \
+              "${tgz}"
+            # skip_existing=true may have skipped the release; only upload if it exists
+            if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              gh release upload "$tag" \
+                "${tgz}.sig" "${tgz}.pem" \
+                --repo "$GITHUB_REPOSITORY" --clobber
+            fi
+          done
+      - name: Push chart to OCI (ghcr.io) and sign with cosign
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          set -euo pipefail
+          helm registry login ghcr.io -u "$GITHUB_ACTOR" -p "${{ secrets.GITHUB_TOKEN }}"
+          for chart in charts/*/; do
+            name=$(basename "$chart")
+            version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
+            tgz="/tmp/${name}-${version}.tgz"
+            push_out=$(helm push "${tgz}" "oci://ghcr.io/${{ github.repository_owner }}/charts" 2>&1 | tee /dev/stderr)
+            digest=$(printf '%s' "$push_out" | grep -oE 'sha256:[a-f0-9]{64}' | head -n1)
+            cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/${name}@${digest}"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Added
 - Initial project scaffolding: Alertmanager + Kubewatch sources, Telegram client with retry/rate-limit/splitting, `text/template` renderer, Prometheus metrics, `/healthz` + `/readyz`.
 - OSS scaffolding: CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, dependabot, issue/PR templates.
-- CI workflow (lint, test, build, trivy fs/image scan).
+- CI workflow (lint, test, build, trivy fs/image scan, chart-lint with `helm lint` + `helm template` + `helm-docs` check).
 - Release workflow (goreleaser binaries, multi-arch container image, cosign keyless signing, SBOM attestation).
+- Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
+- New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
 [Unreleased]: https://github.com/MaksimRudakov/alertly/compare/HEAD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Lint config (`.golangci.yaml`) is intentionally minimal: `gofmt`, `goimports`, `
 
 `Source` is `Name() + Parse([]byte) → []notification.Notification`. Implementations register themselves in `cmd/alertly/main.go` into a `map[string]Source`; the route `POST /v1/{name}/{chats}` is generated from that map. Adding a new source = new file in `internal/source` + entry in the map. The `templateName` passed to the handler equals the source name (with fallback to `default` inside the renderer).
 
-`alertmanager`: standard webhook payload; severity from `labels.severity` (default `info`); title prefers `annotations.summary`, body prefers `annotations.description`; emits Generator/Runbook links.
+`alertmanager`: standard webhook payload; severity from `labels.severity` (default `info`); title prefers `annotations.summary`, body prefers `annotations.description`; emits a Runbook link from `annotations.runbook_url` when present (Prometheus `generatorURL` is intentionally ignored — internal Prometheus links are rarely reachable from Telegram and add noise).
 
 `kubewatch`: tries new (`eventmeta`) format then legacy flat; severity becomes `warning` for `Type=Warning` or `Reason=Failed`; fingerprint is sha256-16 of `kind|namespace|name|reason|type`.
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,38 @@ docker run --rm -p 8080:8080 \
   ghcr.io/maksimrudakov/alertly:latest
 ```
 
-## Quick start (Helm — coming in v0.1.0)
+## Quick start (Helm)
 
 ```bash
 helm repo add alertly https://maksimrudakov.github.io/alertly/
+helm repo update
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --set telegram.botToken=<TOKEN> \
-  --set webhook.authToken=<TOKEN>
+  --set secret.values.telegramBotToken=<TOKEN> \
+  --set secret.values.webhookAuthToken=<TOKEN>
 ```
+
+OCI install (helm ≥ 3.8):
+
+```bash
+helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
+  --version 0.0.1 \
+  --namespace monitoring-system --create-namespace \
+  --set secret.values.telegramBotToken=<TOKEN> \
+  --set secret.values.webhookAuthToken=<TOKEN>
+```
+
+For production use an existing Secret (managed by external-secrets/sealed-secrets/vault):
+
+```bash
+helm install alertly alertly/alertly \
+  --set secret.create=false \
+  --set secret.existingSecret=alertly-tokens
+```
+
+Chart reference: [`charts/alertly/README.md`](./charts/alertly/README.md).
+
+Both the chart tarball (GitHub Release) and the OCI chart are cosign-signed (keyless, Fulcio/Rekor).
 
 ## Endpoints
 

--- a/charts/alertly/.helmignore
+++ b/charts/alertly/.helmignore
@@ -1,0 +1,12 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.vscode/
+.idea/
+*.swp
+*.bak
+*.tmp
+*.orig
+*.log
+OWNERS

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: alertly
+description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
+type: application
+version: 0.0.1
+appVersion: "0.0.2"
+home: https://github.com/MaksimRudakov/alertly
+sources:
+  - https://github.com/MaksimRudakov/alertly
+maintainers:
+  - name: Maksim Rudakov
+    url: https://github.com/MaksimRudakov
+keywords:
+  - alertmanager
+  - kubewatch
+  - telegram
+  - monitoring
+  - notifications
+  - prometheus
+annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/links: |
+    - name: Source
+      url: https://github.com/MaksimRudakov/alertly
+    - name: Container image
+      url: https://github.com/MaksimRudakov/alertly/pkgs/container/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,0 +1,64 @@
+# alertly
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.2](https://img.shields.io/badge/AppVersion-0.0.2-informational?style=flat-square)
+
+Webhook-to-Telegram bridge for Alertmanager and Kubewatch
+
+**Homepage:** <https://github.com/MaksimRudakov/alertly>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Maksim Rudakov |  | <https://github.com/MaksimRudakov> |
+
+## Source Code
+
+* <https://github.com/MaksimRudakov/alertly>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Pod affinity rules. |
+| config | object | see `values.yaml` | Alertly runtime configuration. Serialized verbatim into the ConfigMap mounted at `/etc/alertly/config.yaml`. |
+| env | object | `{"LOG_LEVEL":"info"}` | Env vars passed to the container. Keys become env names, values are quoted as strings. |
+| extraEnv | list | `[]` | Extra env vars in full k8s EnvVar form (supports `valueFrom`). |
+| extraManifests | list | `[]` | Raw manifests rendered as-is. Use for PodMonitor/ServiceMonitor, PDB, NetworkPolicy, etc. without forking the chart.  Example — PodMonitor for kube-prometheus-stack: extraManifests:   - apiVersion: monitoring.coreos.com/v1     kind: PodMonitor     metadata:       name: alertly       labels:         release: kube-prometheus-stack     spec:       selector:         matchLabels:           app.kubernetes.io/name: alertly       podMetricsEndpoints:         - port: http           path: /metrics           interval: 30s  Example — PodDisruptionBudget: extraManifests:   - apiVersion: policy/v1     kind: PodDisruptionBudget     metadata:       name: alertly     spec:       maxUnavailable: 0       selector:         matchLabels:           app.kubernetes.io/name: alertly |
+| fullnameOverride | string | `""` | Override full release name. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| image.repository | string | `"ghcr.io/maksimrudakov/alertly"` | Container image repository. |
+| image.tag | string | `""` | Image tag. Overrides `Chart.AppVersion` when set. |
+| imagePullSecrets | list | `[]` | Pull secrets for private registries. |
+| ingress.annotations | object | `{}` | Ingress annotations (basic-auth, cert-manager, rate-limits, etc). |
+| ingress.className | string | `""` | IngressClass name. |
+| ingress.enabled | bool | `false` | Enable Ingress for the alertly webhook endpoint. |
+| ingress.hosts | list | `[{"host":"alertly.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress host/path rules. |
+| ingress.tls | list | `[]` | Ingress TLS blocks. |
+| nameOverride | string | `""` | Override chart name. |
+| nodeSelector | object | `{}` | Pod nodeSelector. |
+| podAnnotations | object | `{}` | Extra annotations for the pod. |
+| podLabels | object | `{}` | Extra labels for the pod. |
+| podSecurityContext | object | `{"fsGroup":65532,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level security context. |
+| priorityClassName | string | `""` | Pod priorityClassName. |
+| probes.liveness | object | `{"failureThreshold":3,"httpGet":{"path":"/healthz","port":"http"},"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":2}` | Liveness probe. Matches unconditional `/healthz`. |
+| probes.readiness | object | `{"failureThreshold":3,"httpGet":{"path":"/readyz","port":"http"},"initialDelaySeconds":2,"periodSeconds":5,"timeoutSeconds":2}` | Readiness probe. `/readyz` flips unready on sustained 5xx from Telegram or during startup getMe. |
+| reloader.enabled | bool | `false` | Add `reloader.stakater.com/auto: "true"` annotation to the Deployment to auto-restart on ConfigMap/Secret content changes. Requires stakater/Reloader in the cluster. |
+| replicaCount | int | `1` | Number of alertly replicas. alertly is stateless; 1 is enough for most setups. |
+| resources | object | `{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | CPU/memory requests and limits. |
+| secret.create | bool | `true` | Create the Secret with tokens provided in `secret.values`. WARNING — NOT for production; tokens end up in Helm history. For production set `create: false` and supply the Secret via external-secrets/sealed-secrets/vault. |
+| secret.existingSecret | string | `""` | Name of an existing Secret to use when `create: false`. Defaults to release fullname when empty. |
+| secret.keys | object | `{"botToken":"TELEGRAM_BOT_TOKEN","webhookAuth":"WEBHOOK_AUTH_TOKEN"}` | Key names inside the Secret. Must match the env vars alertly reads (`TELEGRAM_BOT_TOKEN`, `WEBHOOK_AUTH_TOKEN`). |
+| secret.values | object | `{"telegramBotToken":"","webhookAuthToken":""}` | Token values used only when `create: true`. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | Container security context. Hardened defaults — read-only rootfs, non-root, all caps dropped. |
+| service.annotations | object | `{}` | Extra annotations for the Service. |
+| service.port | int | `8080` | Service port. |
+| service.type | string | `"ClusterIP"` | Service type. Default ClusterIP — Alertmanager and Kubewatch typically run in the same cluster. |
+| serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount. |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Whether to mount the ServiceAccount token into the pod. alertly does not talk to the Kubernetes API. |
+| serviceAccount.create | bool | `true` | Create a ServiceAccount for the pod. |
+| serviceAccount.name | string | `""` | Use an existing ServiceAccount instead of creating one. Falls back to release fullname when empty and `create: true`. |
+| terminationGracePeriodSeconds | int | `30` | Grace period before SIGKILL. |
+| tolerations | list | `[]` | Pod tolerations. |
+| topologySpreadConstraints | list | `[]` | Pod topology spread constraints. |
+

--- a/charts/alertly/templates/NOTES.txt
+++ b/charts/alertly/templates/NOTES.txt
@@ -1,0 +1,40 @@
+alertly {{ .Chart.AppVersion }} has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+1. Webhook endpoints (inside the cluster):
+
+   http://{{ include "alertly.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/v1/alertmanager/<chat_id>[:<thread_id>]
+   http://{{ include "alertly.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/v1/kubewatch/<chat_id>[:<thread_id>]
+
+   Every request must carry:
+     Authorization: Bearer $WEBHOOK_AUTH_TOKEN
+
+2. Check readiness and metrics:
+
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "alertly.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+   curl localhost:{{ .Values.service.port }}/readyz
+   curl localhost:{{ .Values.service.port }}/metrics | grep alertly_
+
+{{- if .Values.secret.create }}
+
+3. WARNING: `secret.create=true` is set. Tokens live inside the Helm release values
+   and will end up in Helm history (and anywhere your values.yaml is stored).
+   Not suitable for production — switch to `secret.create=false` and manage the
+   Secret via external-secrets/sealed-secrets/vault.
+{{- end }}
+
+{{- if not .Values.reloader.enabled }}
+
+4. Config/Secret changes do NOT trigger a restart automatically. After editing the
+   ConfigMap or Secret, either:
+     - run `kubectl -n {{ .Release.Namespace }} rollout restart deploy/{{ include "alertly.fullname" . }}`, or
+     - install stakater/Reloader and set `reloader.enabled=true` in values.
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+
+5. Ingress is enabled. Hosts:
+{{- range .Values.ingress.hosts }}
+   - {{ .host }}
+{{- end }}
+   Make sure your ingress controller is reachable and that {{ .Values.ingress.className | default "the default IngressClass" }} is configured.
+{{- end }}

--- a/charts/alertly/templates/_helpers.tpl
+++ b/charts/alertly/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alertly.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name. Truncated to 63 chars to comply with DNS limits.
+*/}}
+{{- define "alertly.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart name and version as used by the chart label.
+*/}}
+{{- define "alertly.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "alertly.labels" -}}
+helm.sh/chart: {{ include "alertly.chart" . }}
+{{ include "alertly.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "alertly.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alertly.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "alertly.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "alertly.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Secret name — either created by this chart or an existing one referenced from values.
+*/}}
+{{- define "alertly.secretName" -}}
+{{- if .Values.secret.create -}}
+{{- include "alertly.fullname" . -}}
+{{- else -}}
+{{- default (include "alertly.fullname" .) .Values.secret.existingSecret -}}
+{{- end -}}
+{{- end -}}

--- a/charts/alertly/templates/configmap.yaml
+++ b/charts/alertly/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alertly.fullname" . }}
+  labels:
+    {{- include "alertly.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+{{ toYaml .Values.config | indent 4 }}

--- a/charts/alertly/templates/deployment.yaml
+++ b/charts/alertly/templates/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "alertly.fullname" . }}
+  labels:
+    {{- include "alertly.labels" . | nindent 4 }}
+  {{- if .Values.reloader.enabled }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "alertly.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "alertly.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.secret.create }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "alertly.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: alertly
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: ALERTLY_CONFIG
+              value: /etc/alertly/config.yaml
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "alertly.secretName" . }}
+          livenessProbe:
+            {{- toYaml .Values.probes.liveness | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.probes.readiness | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alertly
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "alertly.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/alertly/templates/extra.yaml
+++ b/charts/alertly/templates/extra.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/alertly/templates/ingress.yaml
+++ b/charts/alertly/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "alertly.fullname" . }}
+  labels:
+    {{- include "alertly.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "alertly.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/alertly/templates/secret.yaml
+++ b/charts/alertly/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.secret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "alertly.fullname" . }}
+  labels:
+    {{- include "alertly.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.secret.keys.botToken }}: {{ required "secret.values.telegramBotToken is required when secret.create=true" .Values.secret.values.telegramBotToken | b64enc }}
+  {{ .Values.secret.keys.webhookAuth }}: {{ required "secret.values.webhookAuthToken is required when secret.create=true" .Values.secret.values.webhookAuthToken | b64enc }}
+{{- end }}

--- a/charts/alertly/templates/service.yaml
+++ b/charts/alertly/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "alertly.fullname" . }}
+  labels:
+    {{- include "alertly.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "alertly.selectorLabels" . | nindent 4 }}

--- a/charts/alertly/templates/serviceaccount.yaml
+++ b/charts/alertly/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "alertly.serviceAccountName" . }}
+  labels:
+    {{- include "alertly.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/alertly/values.yaml
+++ b/charts/alertly/values.yaml
@@ -1,0 +1,223 @@
+## alertly — Helm chart values
+## See https://github.com/MaksimRudakov/alertly for documentation.
+
+# -- Number of alertly replicas. alertly is stateless; 1 is enough for most setups.
+replicaCount: 1
+
+image:
+  # -- Container image repository.
+  repository: ghcr.io/maksimrudakov/alertly
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+  # -- Image tag. Overrides `Chart.AppVersion` when set.
+  tag: ""
+
+# -- Pull secrets for private registries.
+imagePullSecrets: []
+
+# -- Override chart name.
+nameOverride: ""
+# -- Override full release name.
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a ServiceAccount for the pod.
+  create: true
+  # -- Annotations for the ServiceAccount.
+  annotations: {}
+  # -- Whether to mount the ServiceAccount token into the pod. alertly does not talk to the Kubernetes API.
+  automountServiceAccountToken: false
+  # -- Use an existing ServiceAccount instead of creating one. Falls back to release fullname when empty and `create: true`.
+  name: ""
+
+# -- Extra annotations for the pod.
+podAnnotations: {}
+# -- Extra labels for the pod.
+podLabels: {}
+
+# -- Pod-level security context.
+podSecurityContext:
+  fsGroup: 65532
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container security context. Hardened defaults — read-only rootfs, non-root, all caps dropped.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  capabilities:
+    drop:
+      - ALL
+
+# -- CPU/memory requests and limits.
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+probes:
+  # -- Liveness probe. Matches unconditional `/healthz`.
+  liveness:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+  # -- Readiness probe. `/readyz` flips unready on sustained 5xx from Telegram or during startup getMe.
+  readiness:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 2
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 3
+
+service:
+  # -- Service type. Default ClusterIP — Alertmanager and Kubewatch typically run in the same cluster.
+  type: ClusterIP
+  # -- Service port.
+  port: 8080
+  # -- Extra annotations for the Service.
+  annotations: {}
+
+ingress:
+  # -- Enable Ingress for the alertly webhook endpoint.
+  enabled: false
+  # -- IngressClass name.
+  className: ""
+  # -- Ingress annotations (basic-auth, cert-manager, rate-limits, etc).
+  annotations: {}
+  # -- Ingress host/path rules.
+  hosts:
+    - host: alertly.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- Ingress TLS blocks.
+  tls: []
+
+secret:
+  # -- Create the Secret with tokens provided in `secret.values`. WARNING — NOT for production; tokens end up in Helm history. For production set `create: false` and supply the Secret via external-secrets/sealed-secrets/vault.
+  create: true
+  # -- Name of an existing Secret to use when `create: false`. Defaults to release fullname when empty.
+  existingSecret: ""
+  # -- Key names inside the Secret. Must match the env vars alertly reads (`TELEGRAM_BOT_TOKEN`, `WEBHOOK_AUTH_TOKEN`).
+  keys:
+    botToken: TELEGRAM_BOT_TOKEN
+    webhookAuth: WEBHOOK_AUTH_TOKEN
+  # -- Token values used only when `create: true`.
+  values:
+    telegramBotToken: ""
+    webhookAuthToken: ""
+
+# -- Env vars passed to the container. Keys become env names, values are quoted as strings.
+env:
+  LOG_LEVEL: info
+
+# -- Extra env vars in full k8s EnvVar form (supports `valueFrom`).
+extraEnv: []
+
+# -- Grace period before SIGKILL.
+terminationGracePeriodSeconds: 30
+
+# -- Pod nodeSelector.
+nodeSelector: {}
+# -- Pod tolerations.
+tolerations: []
+# -- Pod affinity rules.
+affinity: {}
+# -- Pod topology spread constraints.
+topologySpreadConstraints: []
+# -- Pod priorityClassName.
+priorityClassName: ""
+
+reloader:
+  # -- Add `reloader.stakater.com/auto: "true"` annotation to the Deployment to auto-restart on ConfigMap/Secret content changes. Requires stakater/Reloader in the cluster.
+  enabled: false
+
+# -- Alertly runtime configuration. Serialized verbatim into the ConfigMap mounted at `/etc/alertly/config.yaml`.
+# @default -- see `values.yaml`
+config:
+  server:
+    listen_addr: ":8080"
+    read_timeout: 10s
+    write_timeout: 30s
+    shutdown_timeout: 30s
+    max_body_bytes: 1048576
+  telegram:
+    api_url: "https://api.telegram.org"
+    parse_mode: "HTML"
+    request_timeout: 10s
+    rate_limit:
+      per_chat_per_sec: 1
+      global_per_sec: 30
+    retry:
+      max_attempts: 5
+      initial_backoff: 1s
+      max_backoff: 60s
+  templates:
+    default: |
+      {{ severity_emoji .Severity }} <b>{{ escape_html .Title }}</b>
+      {{ if .Body }}{{ escape_html .Body }}{{ end }}
+      {{- range .Links }}
+      <a href="{{ .URL }}">{{ escape_html .Title }}</a>{{ end }}
+    alertmanager: |
+      <b>{{ escape_html .Title }}</b>
+      <b>Status:</b> {{ if eq .Status "firing" }}Firing 🔥{{ else if eq .Status "resolved" }}Resolved ✅{{ else }}{{ escape_html .Status }}{{ end }}
+      {{- if .Body }}
+      {{ escape_html .Body }}
+      {{- end }}
+      {{- range .Links }}
+      <a href="{{ .URL }}">{{ escape_html .Title }} URL</a>
+      {{- end }}
+
+      <b>Alert Name:</b> {{ escape_html (index .Labels "alertname") }}
+      <b>Severity:</b> {{ .Severity }} {{ severity_emoji .Severity }}
+    kubewatch: |
+      {{ severity_emoji .Severity }} <b>{{ escape_html .Title }}</b>
+      {{ if .Body }}{{ escape_html .Body }}{{ end }}
+  logging:
+    level: "info"
+    format: "json"
+
+# -- Raw manifests rendered as-is. Use for PodMonitor/ServiceMonitor, PDB, NetworkPolicy, etc. without forking the chart.
+#
+# Example — PodMonitor for kube-prometheus-stack:
+# extraManifests:
+#   - apiVersion: monitoring.coreos.com/v1
+#     kind: PodMonitor
+#     metadata:
+#       name: alertly
+#       labels:
+#         release: kube-prometheus-stack
+#     spec:
+#       selector:
+#         matchLabels:
+#           app.kubernetes.io/name: alertly
+#       podMetricsEndpoints:
+#         - port: http
+#           path: /metrics
+#           interval: 30s
+#
+# Example — PodDisruptionBudget:
+# extraManifests:
+#   - apiVersion: policy/v1
+#     kind: PodDisruptionBudget
+#     metadata:
+#       name: alertly
+#     spec:
+#       maxUnavailable: 0
+#       selector:
+#         matchLabels:
+#           app.kubernetes.io/name: alertly
+extraManifests: []

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -24,15 +24,17 @@ templates:
     {{- range .Links }}
     <a href="{{ .URL }}">{{ escape_html .Title }}</a>{{ end }}
   alertmanager: |
-    {{ severity_emoji .Severity }} <b>[{{ .Status }}] {{ escape_html .Title }}</b>
-    {{ if .Body }}{{ escape_html .Body }}
-    {{ end -}}
-    {{- with .Labels.namespace }}<i>ns:</i> {{ escape_html . }}
-    {{ end -}}
-    {{- with .Labels.instance }}<i>instance:</i> {{ escape_html . }}
-    {{ end -}}
+    <b>{{ escape_html .Title }}</b>
+    <b>Status:</b> {{ if eq .Status "firing" }}Firing 🔥{{ else if eq .Status "resolved" }}Resolved ✅{{ else }}{{ escape_html .Status }}{{ end }}
+    {{- if .Body }}
+    {{ escape_html .Body }}
+    {{- end }}
     {{- range .Links }}
-    <a href="{{ .URL }}">{{ escape_html .Title }}</a>{{ end }}
+    <a href="{{ .URL }}">{{ escape_html .Title }} URL</a>
+    {{- end }}
+
+    <b>Alert Name:</b> {{ escape_html (index .Labels "alertname") }}
+    <b>Severity:</b> {{ .Severity }} {{ severity_emoji .Severity }}
   kubewatch: |
     {{ severity_emoji .Severity }} <b>{{ escape_html .Title }}</b>
     {{ if .Body }}{{ escape_html .Body }}{{ end }}

--- a/internal/source/alertmanager.go
+++ b/internal/source/alertmanager.go
@@ -22,13 +22,12 @@ type amPayload struct {
 }
 
 type amAlert struct {
-	Status       string            `json:"status"`
-	Labels       map[string]string `json:"labels"`
-	Annotations  map[string]string `json:"annotations"`
-	StartsAt     time.Time         `json:"startsAt"`
-	EndsAt       time.Time         `json:"endsAt"`
-	GeneratorURL string            `json:"generatorURL"`
-	Fingerprint  string            `json:"fingerprint"`
+	Status      string            `json:"status"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+	StartsAt    time.Time         `json:"startsAt"`
+	EndsAt      time.Time         `json:"endsAt"`
+	Fingerprint string            `json:"fingerprint"`
 }
 
 func (alertmanager) Parse(body []byte) ([]notification.Notification, error) {
@@ -56,10 +55,7 @@ func alertToNotification(a amAlert) notification.Notification {
 	title := firstNonEmpty(a.Annotations["summary"], a.Labels["alertname"])
 	body := firstNonEmpty(a.Annotations["description"], a.Annotations["message"])
 
-	links := make([]notification.Link, 0, 2)
-	if a.GeneratorURL != "" {
-		links = append(links, notification.Link{Title: "Generator", URL: a.GeneratorURL})
-	}
+	links := make([]notification.Link, 0, 1)
 	if v := a.Annotations["runbook_url"]; v != "" {
 		links = append(links, notification.Link{Title: "Runbook", URL: v})
 	}

--- a/internal/source/alertmanager_test.go
+++ b/internal/source/alertmanager_test.go
@@ -42,8 +42,11 @@ func TestAlertmanagerFiring(t *testing.T) {
 	if n.Fingerprint != "abcdef1234567890" {
 		t.Errorf("fingerprint: %s", n.Fingerprint)
 	}
-	if len(n.Links) != 2 {
+	if len(n.Links) != 1 {
 		t.Errorf("links: %d", len(n.Links))
+	}
+	if n.Links[0].Title != "Runbook" {
+		t.Errorf("link title: %s", n.Links[0].Title)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `charts/alertly/` Helm chart — `version: 0.0.1`, `appVersion: "0.0.2"`. Deployment, Service, ConfigMap, Secret (create-true default with NOT-for-prod warning), ServiceAccount, Ingress (opt-in), Reloader annotation (opt-in), `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Release pipeline publishes to **both** GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`); both artifacts are **cosign-signed (keyless, Fulcio/Rekor)**.
- CI: new `chart-lint` job — `helm lint` + `helm template` (defaults + ingress/reloader scenarios) + `helm-docs` staleness check.
- `alertmanager` template reworked: `Title / Status (Firing 🔥 | Resolved ✅) / body / Runbook URL / Alert Name / Severity`. `generatorURL` dropped — internal Prometheus links rarely reachable from Telegram; `runbook_url` kept.
- README Quick-start (Helm) updated for both `helm repo add` and OCI install. CHANGELOG updated.

## Post-merge checklist

- [ ] Tag `v0.0.2` and push — fires the release workflow (goreleaser binaries, multi-arch image 0.0.2, chart 0.0.1 published to gh-pages + OCI, all cosign-signed).
- [ ] After first successful release run — enable GitHub Pages: `Settings → Pages → Source: gh-pages` (branch is created automatically by chart-releaser-action).
- [ ] Add `chart-lint` to required status checks in main branch ruleset.

## Test plan

- [x] `go test -race -count=1 ./...` — all packages green
- [x] `helm lint charts/alertly` — 0 failed
- [x] `helm template test charts/alertly` with defaults + tokens — renders 5 resources
- [x] `helm template ... --set ingress.enabled=true --set reloader.enabled=true --set extraManifests=[PodMonitor]` — all opt-ins render correctly
- [x] `helm-docs --chart-search-root=charts` — no diff (README up to date)
- [x] End-to-end sanity: locally ran `./bin/alertly` with `TELEGRAM_BOT_TOKEN` + `WEBHOOK_AUTH_TOKEN`, posted `testdata/alertmanager_firing.json` + `alertmanager_resolved.json` + `kubewatch_warning.json` + `alertmanager_grouped.json` — all HTTP 200, 0 retries, 6 messages delivered to the target chat; verified new alertmanager rendering and absence of `Generator URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)