### PR TITLE
fix(ci): lowercase owner for helm push to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,12 +143,15 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           set -euo pipefail
+          # ghcr.io requires a lowercase repository path; github.repository_owner
+          # preserves the original casing, so lower-case it explicitly.
+          owner_lc=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           helm registry login ghcr.io -u "$GITHUB_ACTOR" -p "${{ secrets.GITHUB_TOKEN }}"
           for chart in charts/*/; do
             name=$(basename "$chart")
             version=$(grep '^version:' "$chart/Chart.yaml" | awk '{print $2}')
             tgz="/tmp/${name}-${version}.tgz"
-            push_out=$(helm push "${tgz}" "oci://ghcr.io/${{ github.repository_owner }}/charts" 2>&1 | tee /dev/stderr)
+            push_out=$(helm push "${tgz}" "oci://ghcr.io/${owner_lc}/charts" 2>&1 | tee /dev/stderr)
             digest=$(printf '%s' "$push_out" | grep -oE 'sha256:[a-f0-9]{64}' | head -n1)
-            cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/${name}@${digest}"
+            cosign sign --yes "ghcr.io/${owner_lc}/charts/${name}@${digest}"
           done


### PR DESCRIPTION
## Summary

OCI push of the Helm chart failed in the `v0.0.2` release run with `invalid_reference: invalid repository`. Root cause: `github.repository_owner` preserves the original casing (`MaksimRudakov`) and OCI registries (ghcr.io included) require the repository path to be lowercase. `docker/metadata-action` already lowercases for the container image, so the `docker` job passed — only the `helm push` / `cosign sign` step for the OCI chart manifest needed the conversion.

## Fix

`tr '[:upper:]' '[:lower:]'` on `${{ github.repository_owner }}` before composing the OCI URL, same variable reused for `cosign sign`.

## Verification plan

After merge, delete and recreate tag `v0.0.2` (or push `v0.0.3`) to re-trigger the release workflow. The `Push chart to OCI` step should then publish `oci://ghcr.io/maksimrudakov/charts/alertly:0.0.1` and cosign-sign it keylessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)