### PR TITLE
fix(ci): docker login to ghcr.io before cosign sign of OCI chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,6 +109,11 @@ jobs:
         with:
           version: v3.16.0
       - uses: sigstore/cosign-installer@v3
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts


### PR DESCRIPTION
## Summary

Third run of the v0.0.2 release got the Helm chart into OCI (`oci://ghcr.io/maksimrudakov/charts/alertly`) but failed on cosign sign with:

```
UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided
```

`helm registry login` writes `~/.config/helm/registry/config.json`; cosign reads credentials from the Docker config only. Adding `docker/login-action` before the chart-release steps creates `~/.docker/config.json`, which cosign picks up. The subsequent `helm registry login` remains for `helm push`.

## Test plan

- [ ] After merge, delete+recreate tag `v0.0.2` — `Push chart to OCI` step should finish signing the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)