### PR TITLE
test(metrics): cover alertly_source_parse_duration_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Tests
 - `internal/server` coverage raised from **62.7% → 90.8%**: new unit tests for `ReadinessTracker` (`MarkReady` / `MarkUnready` / `RecordSendFailure` — including the 10-failure window, client-error ignore path, and success-reset), handler multi-status (`207`) and all-failed (`500`) branches, `400` paths (invalid chat list, source parse error), `isServerError` table test (nil / non-api / 4xx / 429 / 5xx), `recoverMiddleware` panic path, and `Server.Run` graceful shutdown on ctx cancel.
+- `alertly_source_parse_duration_seconds` histogram — new test asserts the sample count grows by 1 on both the happy path and the parse-error path, that the sum is positive, and that the `source` label does not leak between sources.
 
 ### Changed
 - `release.yaml`: dropped the standalone `anchore/sbom-action` step. SBOM is already produced by `docker/build-push-action` (`sbom: true`) and attached to the image as an OCI attestation, so the extra step was redundant and was failing on syft exit code 1.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -446,6 +446,70 @@ func TestRecoverMiddleware(t *testing.T) {
 	}
 }
 
+// TestSourceParseDurationMetric: the histogram observes a sample on every
+// webhook call regardless of whether Parse succeeds or fails (handler
+// Observe()s before inspecting the error).
+func TestSourceParseDurationMetric(t *testing.T) {
+	rec := newTelegramRecorder(t)
+	ts := newTestServer(t, rec, 1000)
+
+	countBefore, sumBefore := parseDurationHistogram(t, "alertmanager")
+
+	// Happy path — valid payload.
+	resp := doPost(t, ts.URL, "/v1/alertmanager/-100", loadFixture(t, "alertmanager_firing.json"), nil)
+	resp.Body.Close()
+	countAfterOK, sumAfterOK := parseDurationHistogram(t, "alertmanager")
+	if countAfterOK != countBefore+1 {
+		t.Errorf("after valid payload: count %d -> %d, expected +1", countBefore, countAfterOK)
+	}
+	if sumAfterOK <= sumBefore {
+		t.Errorf("after valid payload: sum did not grow (%v -> %v)", sumBefore, sumAfterOK)
+	}
+
+	// Parse-error path — malformed JSON still triggers Parse and still Observe()s.
+	resp = doPost(t, ts.URL, "/v1/alertmanager/-100", []byte("not-json"), nil)
+	resp.Body.Close()
+	countAfterErr, _ := parseDurationHistogram(t, "alertmanager")
+	if countAfterErr != countAfterOK+1 {
+		t.Errorf("after parse error: count %d -> %d, expected +1", countAfterOK, countAfterErr)
+	}
+
+	// Labels must not leak between sources.
+	if countKW, _ := parseDurationHistogram(t, "kubewatch"); countKW != 0 && countKW == countAfterErr {
+		t.Errorf("alertmanager count leaked into kubewatch source label")
+	}
+}
+
+// parseDurationHistogram returns (sample_count, sample_sum) for
+// alertly_source_parse_duration_seconds{source=<src>} from the global registry.
+func parseDurationHistogram(t *testing.T, src string) (uint64, float64) {
+	t.Helper()
+	mfs, err := metrics.Registry().Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "alertly_source_parse_duration_seconds" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			match := false
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "source" && lp.GetValue() == src {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+			h := m.GetHistogram()
+			return h.GetSampleCount(), h.GetSampleSum()
+		}
+	}
+	return 0, 0
+}
+
 // TestServerRunGracefulShutdown: ctx cancel → Run returns nil within timeout.
 func TestServerRunGracefulShutdown(t *testing.T) {
 	rec := newTelegramRecorder(t)


### PR DESCRIPTION
## Summary

Closes the last TODO code-gap item: a unit test for the \`alertly_source_parse_duration_seconds\` histogram.

## What the test asserts

- Happy path: a valid webhook → sample count += 1, sample sum > 0.
- Error path: malformed JSON → sample count **still** += 1, because handler \`Observe()\`s before inspecting the Parse error. This is the behaviour we care about (we want visibility into parse time even when parse fails).
- \`source\` label isolation: alertmanager observations do not bleed into \`source=kubewatch\`.

## Implementation detail

The test server gives \`webhookHandler\` a throwaway \`prometheus.Registry\`, but \`Observe()\` targets the package-level \`metrics.Registry()\`. The test reads that global \`Gatherer\` directly via the protobuf \`MetricFamily\` API — simpler than spinning up a second \`/metrics\` endpoint.

## Test plan

- [x] \`go test -race -run TestSourceParseDurationMetric ./internal/server\` — pass
- [x] Full suite green, coverage still 90.8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)