### PR TITLE
chore(release): v0.0.3 (chart 0.0.2 / appVersion 0.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-04-21
+
+Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to keep chart `appVersion` aligned with the code state after the following doc/test/example work.
+
 ### Added
 - `examples/alertmanager-config.yaml` — Alertmanager receiver config with Bearer-token auth, multi-chat URL and per-chat forum-thread (`:thread_id`) routing.
 - `examples/kubewatch-config.yaml` — robusta-dev/kubewatch ConfigMap + Deployment pointing at alertly with an `Authorization: Bearer` header.
@@ -17,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - `alertly_source_parse_duration_seconds` histogram — new test asserts the sample count grows by 1 on both the happy path and the parse-error path, that the sum is positive, and that the `source` label does not leak between sources.
 
 ### Changed
+- Helm chart bumped to `version: 0.0.2`, `appVersion: "0.0.3"`.
 - `release.yaml`: dropped the standalone `anchore/sbom-action` step. SBOM is already produced by `docker/build-push-action` (`sbom: true`) and attached to the image as an OCI attestation, so the extra step was redundant and was failing on syft exit code 1.
 
 ## [0.0.1] - 2026-04-21
@@ -29,5 +34,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
 - New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.0.1...HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/MaksimRudakov/alertly/compare/v0.0.1...v0.0.3
 [0.0.1]: https://github.com/MaksimRudakov/alertly/releases/tag/v0.0.1

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.0.1
-appVersion: "0.0.2"
+version: 0.0.2
+appVersion: "0.0.3"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.2](https://img.shields.io/badge/AppVersion-0.0.2-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 


### PR DESCRIPTION
## Summary

Version bump for the next tag. Runtime is unchanged vs \`v0.0.2\` — only docs, tests and examples landed since then. The reason for a new tag is to keep the Helm chart's \`appVersion\` aligned with what's on main so anyone pulling the chart gets a pin to a freshly-built image.

- \`charts/alertly/Chart.yaml\`: \`version\` 0.0.1 → **0.0.2**, \`appVersion\` "0.0.2" → **"0.0.3"**
- \`charts/alertly/README.md\` regenerated by helm-docs
- \`CHANGELOG.md\`: moves the accumulated \`[Unreleased]\` entries into \`[0.0.3]\` with a note that runtime is unchanged

## After merge

```
git tag v0.0.3 && git push origin v0.0.3
```

…which triggers \`release.yaml\`:

- goreleaser → binaries for linux/darwin × amd64/arm64
- docker build & cosign sign for \`ghcr.io/maksimrudakov/alertly:0.0.3\` (+ \`0.0\`, \`0\`, \`latest\`)
- chart-releaser + OCI push + cosign for the chart tarball and the OCI manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)