### PR TITLE
feat(updates): interactive silence buttons via Telegram long polling

### DIFF
--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -22,6 +22,12 @@ Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Pod affinity rules. |
 | config | object | see `values.yaml` | Alertly runtime configuration. Serialized verbatim into the ConfigMap mounted at `/etc/alertly/config.yaml`. |
+| config.alertmanager | object | `{"request_timeout":"10s","url":""}` | Alertmanager connection for the silence action. Required when updates.enabled=true. Auth is supplied via env: ALERTMANAGER_AUTH_USERNAME + _PASSWORD (basic) or ALERTMANAGER_AUTH_TOKEN (bearer). See `secret.values.alertmanager*` below. |
+| config.updates | object | `{"button_ttl":"8h","chat_allowlist":[],"enabled":false,"label_cache_max":10000,"label_cache_ttl":"48h","poll_timeout":"30s","silence_durations":["1h","4h","24h"],"user_allowlist":[]}` | Interactive callbacks (Telegram long polling) and Alertmanager silence integration. Keep disabled unless on-call needs in-chat silence buttons. |
+| config.updates.button_ttl | string | `"8h"` | How long silence buttons stay active on an alert message (2h..48h). After this window the sweeper removes the keyboard and late clicks are rejected. |
+| config.updates.chat_allowlist | list | `[]` | Chats allowed to trigger silence actions. Empty list = silence disabled. |
+| config.updates.silence_durations | list | `["1h","4h","24h"]` | Silence durations presented as buttons. Each entry becomes one button. |
+| config.updates.user_allowlist | list | `[]` | Optional user allowlist within allowlisted chats. Empty = any chat member. |
 | env | object | `{"LOG_LEVEL":"info"}` | Env vars passed to the container. Keys become env names, values are quoted as strings. |
 | extraEnv | list | `[]` | Extra env vars in full k8s EnvVar form (supports `valueFrom`). |
 | extraManifests | list | `[]` | Raw manifests rendered as-is. Use for PodMonitor/ServiceMonitor, PDB, NetworkPolicy, etc. without forking the chart.  Example — PodMonitor for kube-prometheus-stack: extraManifests:   - apiVersion: monitoring.coreos.com/v1     kind: PodMonitor     metadata:       name: alertly       labels:         release: kube-prometheus-stack     spec:       selector:         matchLabels:           app.kubernetes.io/name: alertly       podMetricsEndpoints:         - port: http           path: /metrics           interval: 30s  Example — PodDisruptionBudget: extraManifests:   - apiVersion: policy/v1     kind: PodDisruptionBudget     metadata:       name: alertly     spec:       maxUnavailable: 0       selector:         matchLabels:           app.kubernetes.io/name: alertly |
@@ -48,8 +54,8 @@ Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 | resources | object | `{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | CPU/memory requests and limits. |
 | secret.create | bool | `true` | Create the Secret with tokens provided in `secret.values`. WARNING — NOT for production; tokens end up in Helm history. For production set `create: false` and supply the Secret via external-secrets/sealed-secrets/vault. |
 | secret.existingSecret | string | `""` | Name of an existing Secret to use when `create: false`. Defaults to release fullname when empty. |
-| secret.keys | object | `{"botToken":"TELEGRAM_BOT_TOKEN","webhookAuth":"WEBHOOK_AUTH_TOKEN"}` | Key names inside the Secret. Must match the env vars alertly reads (`TELEGRAM_BOT_TOKEN`, `WEBHOOK_AUTH_TOKEN`). |
-| secret.values | object | `{"telegramBotToken":"","webhookAuthToken":""}` | Token values used only when `create: true`. |
+| secret.keys | object | `{"alertmanagerPassword":"ALERTMANAGER_AUTH_PASSWORD","alertmanagerToken":"ALERTMANAGER_AUTH_TOKEN","alertmanagerUsername":"ALERTMANAGER_AUTH_USERNAME","botToken":"TELEGRAM_BOT_TOKEN","webhookAuth":"WEBHOOK_AUTH_TOKEN"}` | Key names inside the Secret. Must match the env vars alertly reads. Alertmanager keys are used only when `config.updates.enabled=true` AND the corresponding `secret.values.*` is set. |
+| secret.values | object | `{"alertmanagerPassword":"","alertmanagerToken":"","alertmanagerUsername":"","telegramBotToken":"","webhookAuthToken":""}` | Token values used only when `create: true`. Alertmanager fields are optional. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | Container security context. Hardened defaults — read-only rootfs, non-root, all caps dropped. |
 | service.annotations | object | `{}` | Extra annotations for the Service. |
 | service.port | int | `8080` | Service port. |

--- a/charts/alertly/templates/secret.yaml
+++ b/charts/alertly/templates/secret.yaml
@@ -9,4 +9,13 @@ type: Opaque
 data:
   {{ .Values.secret.keys.botToken }}: {{ required "secret.values.telegramBotToken is required when secret.create=true" .Values.secret.values.telegramBotToken | b64enc }}
   {{ .Values.secret.keys.webhookAuth }}: {{ required "secret.values.webhookAuthToken is required when secret.create=true" .Values.secret.values.webhookAuthToken | b64enc }}
+  {{- with .Values.secret.values.alertmanagerUsername }}
+  {{ $.Values.secret.keys.alertmanagerUsername }}: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.secret.values.alertmanagerPassword }}
+  {{ $.Values.secret.keys.alertmanagerPassword }}: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.secret.values.alertmanagerToken }}
+  {{ $.Values.secret.keys.alertmanagerToken }}: {{ . | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/alertly/values.yaml
+++ b/charts/alertly/values.yaml
@@ -111,14 +111,21 @@ secret:
   create: true
   # -- Name of an existing Secret to use when `create: false`. Defaults to release fullname when empty.
   existingSecret: ""
-  # -- Key names inside the Secret. Must match the env vars alertly reads (`TELEGRAM_BOT_TOKEN`, `WEBHOOK_AUTH_TOKEN`).
+  # -- Key names inside the Secret. Must match the env vars alertly reads.
+  # Alertmanager keys are used only when `config.updates.enabled=true` AND the corresponding `secret.values.*` is set.
   keys:
     botToken: TELEGRAM_BOT_TOKEN
     webhookAuth: WEBHOOK_AUTH_TOKEN
-  # -- Token values used only when `create: true`.
+    alertmanagerUsername: ALERTMANAGER_AUTH_USERNAME
+    alertmanagerPassword: ALERTMANAGER_AUTH_PASSWORD
+    alertmanagerToken: ALERTMANAGER_AUTH_TOKEN
+  # -- Token values used only when `create: true`. Alertmanager fields are optional.
   values:
     telegramBotToken: ""
     webhookAuthToken: ""
+    alertmanagerUsername: ""
+    alertmanagerPassword: ""
+    alertmanagerToken: ""
 
 # -- Env vars passed to the container. Keys become env names, values are quoted as strings.
 env:
@@ -189,6 +196,33 @@ config:
   logging:
     level: "info"
     format: "json"
+
+  # -- Interactive callbacks (Telegram long polling) and Alertmanager silence integration.
+  # Keep disabled unless on-call needs in-chat silence buttons.
+  updates:
+    enabled: false
+    poll_timeout: 30s
+    # -- Chats allowed to trigger silence actions. Empty list = silence disabled.
+    chat_allowlist: []
+    # -- Optional user allowlist within allowlisted chats. Empty = any chat member.
+    user_allowlist: []
+    # -- Silence durations presented as buttons. Each entry becomes one button.
+    silence_durations:
+      - "1h"
+      - "4h"
+      - "24h"
+    label_cache_ttl: 48h
+    label_cache_max: 10000
+    # -- How long silence buttons stay active on an alert message (2h..48h).
+    # After this window the sweeper removes the keyboard and late clicks are rejected.
+    button_ttl: 8h
+
+  # -- Alertmanager connection for the silence action. Required when updates.enabled=true.
+  # Auth is supplied via env: ALERTMANAGER_AUTH_USERNAME + _PASSWORD (basic) or ALERTMANAGER_AUTH_TOKEN (bearer).
+  # See `secret.values.alertmanager*` below.
+  alertmanager:
+    url: ""
+    request_timeout: 10s
 
 # -- Raw manifests rendered as-is. Use for PodMonitor/ServiceMonitor, PDB, NetworkPolicy, etc. without forking the chart.
 #

--- a/cmd/alertly/main.go
+++ b/cmd/alertly/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/MaksimRudakov/alertly/internal/alertmanager"
 	"github.com/MaksimRudakov/alertly/internal/config"
 	"github.com/MaksimRudakov/alertly/internal/metrics"
 	"github.com/MaksimRudakov/alertly/internal/server"
@@ -79,6 +80,23 @@ func run() error {
 
 	readiness := server.NewReadiness()
 
+	var (
+		keyboard       server.KeyboardBuilder
+		trackerReg     server.ButtonRegistrar
+		bgWorkers      []func(context.Context)
+	)
+	if cfg.Updates.Enabled {
+		if dryRun {
+			logger.Warn("updates.enabled=true ignored under DRY_RUN")
+		} else {
+			var err error
+			keyboard, trackerReg, bgWorkers, err = setupUpdates(cfg, tgClient, logger)
+			if err != nil {
+				return fmt.Errorf("updates: %w", err)
+			}
+		}
+	}
+
 	srv := server.New(cfg.Server, server.Deps{
 		Logger:    logger,
 		Sources:   sources,
@@ -87,6 +105,8 @@ func run() error {
 		Readiness: readiness,
 		AuthToken: authToken,
 		Registry:  registry,
+		Keyboard:  keyboard,
+		Tracker:   trackerReg,
 	})
 
 	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -99,7 +119,76 @@ func run() error {
 		go startupCheck(rootCtx, tgClient, readiness, logger)
 	}
 
+	for _, w := range bgWorkers {
+		go w(rootCtx)
+	}
+
 	return srv.Run(rootCtx)
+}
+
+func setupUpdates(cfg config.Config, tgClient telegram.Client, logger *slog.Logger) (server.KeyboardBuilder, server.ButtonRegistrar, []func(context.Context), error) {
+	amCfg := alertmanager.Config{
+		URL:            cfg.Alertmanager.URL,
+		RequestTimeout: cfg.Alertmanager.RequestTimeout,
+		Auth: alertmanager.Auth{
+			Username: os.Getenv("ALERTMANAGER_AUTH_USERNAME"),
+			Password: os.Getenv("ALERTMANAGER_AUTH_PASSWORD"),
+			Token:    os.Getenv("ALERTMANAGER_AUTH_TOKEN"),
+		},
+	}
+	amClient := alertmanager.New(amCfg)
+
+	cache := alertmanager.NewLabelCache(cfg.Updates.LabelCacheTTL, cfg.Updates.LabelCacheMax)
+	tracker := server.NewButtonTracker(cfg.Updates.ButtonTTL)
+
+	durations := make(map[string]time.Duration, len(cfg.Updates.SilenceDurations))
+	for _, d := range cfg.Updates.SilenceDurations {
+		parsed, err := time.ParseDuration(d)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("parse silence duration %q: %w", d, err)
+		}
+		durations[d] = parsed
+	}
+
+	handler := server.NewCallbackHandler(server.CallbackDeps{
+		Logger:        logger,
+		Telegram:      tgClient,
+		AM:            amClient,
+		Cache:         cache,
+		Tracker:       tracker,
+		ChatAllowlist: cfg.Updates.ChatAllowlist,
+		UserAllowlist: cfg.Updates.UserAllowlist,
+		Durations:     durations,
+	})
+
+	keyboard := &server.AlertmanagerKeyboard{
+		Durations:     cfg.Updates.SilenceDurations,
+		ChatAllowlist: cfg.Updates.ChatAllowlist,
+		Cache:         cache,
+	}
+
+	poller := &server.UpdatesPoller{
+		Client:      tgClient,
+		Handler:     handler,
+		Logger:      logger,
+		PollTimeout: cfg.Updates.PollTimeout,
+	}
+
+	sweeper := &server.ButtonSweeper{
+		Tracker:  tracker,
+		Telegram: tgClient,
+		Logger:   logger,
+		Interval: time.Minute,
+	}
+
+	logger.Info("telegram updates enabled",
+		"chat_allowlist", len(cfg.Updates.ChatAllowlist),
+		"user_allowlist", len(cfg.Updates.UserAllowlist),
+		"durations", cfg.Updates.SilenceDurations,
+		"button_ttl", cfg.Updates.ButtonTTL,
+		"alertmanager_url", cfg.Alertmanager.URL,
+	)
+	return keyboard, tracker, []func(context.Context){poller.Run, sweeper.Run}, nil
 }
 
 func newLogger(cfg config.Logging) *slog.Logger {

--- a/cmd/alertly/main.go
+++ b/cmd/alertly/main.go
@@ -81,9 +81,9 @@ func run() error {
 	readiness := server.NewReadiness()
 
 	var (
-		keyboard       server.KeyboardBuilder
-		trackerReg     server.ButtonRegistrar
-		bgWorkers      []func(context.Context)
+		keyboard   server.KeyboardBuilder
+		trackerReg server.ButtonRegistrar
+		bgWorkers  []func(context.Context)
 	)
 	if cfg.Updates.Enabled {
 		if dryRun {

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -42,3 +42,27 @@ templates:
 logging:
   level: "info"
   format: "json"
+
+# Interactive callbacks (long polling) and Alertmanager silence integration.
+# Leave disabled unless on-call needs in-chat silence buttons.
+updates:
+  enabled: false
+  poll_timeout: 30s
+  # chat_allowlist: chats allowed to trigger silence actions. Empty = disabled.
+  chat_allowlist: []
+  # user_allowlist: optional. Empty = any user in an allowlisted chat.
+  user_allowlist: []
+  silence_durations: ["1h", "4h", "24h"]
+  label_cache_ttl: 48h
+  label_cache_max: 10000
+  # button_ttl: how long silence buttons stay active on an alert message.
+  # After this window the inline keyboard is removed and late clicks are rejected.
+  # Allowed range: 2h..48h.
+  button_ttl: 8h
+
+alertmanager:
+  url: ""                 # e.g. http://alertmanager.monitoring.svc:9093
+  request_timeout: 10s
+  # Auth via env (optional):
+  #   ALERTMANAGER_AUTH_USERNAME + ALERTMANAGER_AUTH_PASSWORD (basic), or
+  #   ALERTMANAGER_AUTH_TOKEN (bearer).

--- a/internal/alertmanager/cache.go
+++ b/internal/alertmanager/cache.go
@@ -1,0 +1,96 @@
+package alertmanager
+
+import (
+	"sync"
+	"time"
+)
+
+// LabelCache stores a bounded, time-limited mapping fingerprint -> labels.
+// It is populated when alertly forwards a notification to Telegram and is
+// consulted by the callback handler as a fallback when Alertmanager does not
+// return the alert (e.g., already resolved/expired). Eviction is FIFO by
+// insertion order once MaxEntries is reached.
+type LabelCache struct {
+	mu         sync.Mutex
+	entries    map[string]cacheEntry
+	order      []string
+	ttl        time.Duration
+	maxEntries int
+	now        func() time.Time
+}
+
+type cacheEntry struct {
+	labels    map[string]string
+	expiresAt time.Time
+}
+
+func NewLabelCache(ttl time.Duration, maxEntries int) *LabelCache {
+	return &LabelCache{
+		entries:    make(map[string]cacheEntry),
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		now:        time.Now,
+	}
+}
+
+func (c *LabelCache) Put(fingerprint string, labels map[string]string) {
+	if c == nil || fingerprint == "" || len(labels) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	copied := make(map[string]string, len(labels))
+	for k, v := range labels {
+		copied[k] = v
+	}
+
+	if _, exists := c.entries[fingerprint]; !exists {
+		c.order = append(c.order, fingerprint)
+		c.evictLocked()
+	}
+	c.entries[fingerprint] = cacheEntry{
+		labels:    copied,
+		expiresAt: c.now().Add(c.ttl),
+	}
+}
+
+func (c *LabelCache) Get(fingerprint string) (map[string]string, bool) {
+	if c == nil || fingerprint == "" {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[fingerprint]
+	if !ok {
+		return nil, false
+	}
+	if c.now().After(entry.expiresAt) {
+		c.removeLocked(fingerprint)
+		return nil, false
+	}
+	out := make(map[string]string, len(entry.labels))
+	for k, v := range entry.labels {
+		out[k] = v
+	}
+	return out, true
+}
+
+func (c *LabelCache) evictLocked() {
+	for len(c.order) > c.maxEntries {
+		oldest := c.order[0]
+		c.order = c.order[1:]
+		delete(c.entries, oldest)
+	}
+}
+
+func (c *LabelCache) removeLocked(fingerprint string) {
+	delete(c.entries, fingerprint)
+	for i, fp := range c.order {
+		if fp == fingerprint {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			return
+		}
+	}
+}

--- a/internal/alertmanager/cache_test.go
+++ b/internal/alertmanager/cache_test.go
@@ -1,0 +1,75 @@
+package alertmanager
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLabelCache_PutGet(t *testing.T) {
+	c := NewLabelCache(time.Hour, 10)
+	c.Put("fp1", map[string]string{"a": "1"})
+	labels, ok := c.Get("fp1")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if labels["a"] != "1" {
+		t.Errorf("labels: %+v", labels)
+	}
+}
+
+func TestLabelCache_TTLExpires(t *testing.T) {
+	c := NewLabelCache(time.Millisecond, 10)
+	// Freeze clock so the test isn't flaky under CI load.
+	now := time.Unix(0, 0)
+	c.now = func() time.Time { return now }
+	c.Put("fp", map[string]string{"a": "1"})
+	now = now.Add(time.Second)
+	if _, ok := c.Get("fp"); ok {
+		t.Error("expected expiry")
+	}
+}
+
+func TestLabelCache_EvictsOldest(t *testing.T) {
+	c := NewLabelCache(time.Hour, 2)
+	c.Put("fp1", map[string]string{"a": "1"})
+	c.Put("fp2", map[string]string{"b": "2"})
+	c.Put("fp3", map[string]string{"c": "3"})
+
+	if _, ok := c.Get("fp1"); ok {
+		t.Error("fp1 should have been evicted")
+	}
+	if _, ok := c.Get("fp2"); !ok {
+		t.Error("fp2 should still be present")
+	}
+	if _, ok := c.Get("fp3"); !ok {
+		t.Error("fp3 should be present")
+	}
+}
+
+func TestLabelCache_UpdatePreservesOrder(t *testing.T) {
+	c := NewLabelCache(time.Hour, 2)
+	c.Put("fp1", map[string]string{"a": "1"})
+	c.Put("fp2", map[string]string{"b": "2"})
+	c.Put("fp1", map[string]string{"a": "new"}) // update, not insert
+	c.Put("fp3", map[string]string{"c": "3"})
+
+	// Order was fp1, fp2; update keeps fp1 in original slot → eviction removes fp1.
+	if _, ok := c.Get("fp1"); ok {
+		t.Error("fp1 should have been evicted (oldest by insertion, not by update)")
+	}
+	if _, ok := c.Get("fp2"); !ok {
+		t.Error("fp2 should be present")
+	}
+	labels, ok := c.Get("fp3")
+	if !ok || labels["c"] != "3" {
+		t.Errorf("fp3: ok=%v labels=%+v", ok, labels)
+	}
+}
+
+func TestLabelCache_NilSafe(t *testing.T) {
+	var c *LabelCache
+	c.Put("fp", map[string]string{"a": "1"})
+	if _, ok := c.Get("fp"); ok {
+		t.Error("nil cache should return false")
+	}
+}

--- a/internal/alertmanager/client.go
+++ b/internal/alertmanager/client.go
@@ -1,0 +1,206 @@
+package alertmanager
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type Config struct {
+	URL            string
+	RequestTimeout time.Duration
+	Auth           Auth
+}
+
+type Auth struct {
+	Username string
+	Password string
+	Token    string
+}
+
+func (a Auth) apply(req *http.Request) {
+	switch {
+	case a.Token != "":
+		req.Header.Set("Authorization", "Bearer "+a.Token)
+	case a.Username != "" || a.Password != "":
+		req.SetBasicAuth(a.Username, a.Password)
+	}
+}
+
+type Client interface {
+	GetAlertLabels(ctx context.Context, fingerprint string) (map[string]string, error)
+	CreateSilence(ctx context.Context, req SilenceRequest) (string, error)
+}
+
+type Matcher struct {
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+	IsRegex bool   `json:"isRegex"`
+	IsEqual bool   `json:"isEqual"`
+}
+
+type SilenceRequest struct {
+	Matchers  []Matcher `json:"matchers"`
+	StartsAt  time.Time `json:"startsAt"`
+	EndsAt    time.Time `json:"endsAt"`
+	CreatedBy string    `json:"createdBy"`
+	Comment   string    `json:"comment"`
+}
+
+type silenceResponse struct {
+	SilenceID string `json:"silenceID"`
+}
+
+type alert struct {
+	Fingerprint string            `json:"fingerprint"`
+	Labels      map[string]string `json:"labels"`
+}
+
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("alertmanager API %d", e.StatusCode)
+	}
+	return fmt.Sprintf("alertmanager API %d: %s", e.StatusCode, e.Body)
+}
+
+var ErrAlertNotFound = errors.New("alert not found in alertmanager")
+
+type client struct {
+	cfg  Config
+	http *http.Client
+}
+
+func New(cfg Config) Client {
+	if cfg.RequestTimeout <= 0 {
+		cfg.RequestTimeout = 10 * time.Second
+	}
+	return &client{
+		cfg:  cfg,
+		http: &http.Client{Timeout: cfg.RequestTimeout},
+	}
+}
+
+func (c *client) GetAlertLabels(ctx context.Context, fingerprint string) (map[string]string, error) {
+	if fingerprint == "" {
+		return nil, errors.New("fingerprint is empty")
+	}
+	// AM v2 API does not expose fingerprint filter directly; fetch active+silenced
+	// and match client-side. Typical alert volume makes this acceptable.
+	u, err := url.Parse(c.cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parse alertmanager url: %w", err)
+	}
+	u.Path = joinPath(u.Path, "/api/v2/alerts")
+	q := u.Query()
+	q.Set("active", "true")
+	q.Set("silenced", "true")
+	q.Set("inhibited", "true")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	c.cfg.Auth.apply(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("alertmanager get alerts: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+
+	var alerts []alert
+	if err := json.Unmarshal(body, &alerts); err != nil {
+		return nil, fmt.Errorf("decode alerts: %w", err)
+	}
+	for _, a := range alerts {
+		if a.Fingerprint == fingerprint {
+			return a.Labels, nil
+		}
+	}
+	return nil, ErrAlertNotFound
+}
+
+func (c *client) CreateSilence(ctx context.Context, sreq SilenceRequest) (string, error) {
+	u, err := url.Parse(c.cfg.URL)
+	if err != nil {
+		return "", fmt.Errorf("parse alertmanager url: %w", err)
+	}
+	u.Path = joinPath(u.Path, "/api/v2/silences")
+
+	body, err := json.Marshal(sreq)
+	if err != nil {
+		return "", fmt.Errorf("marshal silence: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	c.cfg.Auth.apply(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("alertmanager create silence: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
+	var sr silenceResponse
+	if err := json.Unmarshal(respBody, &sr); err != nil {
+		return "", fmt.Errorf("decode silence response: %w", err)
+	}
+	if sr.SilenceID == "" {
+		return "", fmt.Errorf("alertmanager returned empty silenceID: %s", string(respBody))
+	}
+	return sr.SilenceID, nil
+}
+
+func joinPath(base, rel string) string {
+	if base == "" {
+		return rel
+	}
+	if base[len(base)-1] == '/' {
+		base = base[:len(base)-1]
+	}
+	if rel == "" {
+		return base
+	}
+	if rel[0] != '/' {
+		rel = "/" + rel
+	}
+	return base + rel
+}
+
+// MatchersFromLabels builds exact-match matchers from a label map.
+// All labels are included; callers should pre-filter if narrower matchers are desired.
+func MatchersFromLabels(labels map[string]string) []Matcher {
+	out := make([]Matcher, 0, len(labels))
+	for k, v := range labels {
+		out = append(out, Matcher{Name: k, Value: v, IsRegex: false, IsEqual: true})
+	}
+	return out
+}

--- a/internal/alertmanager/client_test.go
+++ b/internal/alertmanager/client_test.go
@@ -1,0 +1,153 @@
+package alertmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetAlertLabels_Found(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/alerts" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("active") != "true" {
+			t.Errorf("missing active filter")
+		}
+		_, _ = io.WriteString(w, `[{"fingerprint":"fp1","labels":{"alertname":"HighCPU","severity":"warning"}},{"fingerprint":"fp2","labels":{"alertname":"Other"}}]`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, RequestTimeout: 2 * time.Second})
+	labels, err := c.GetAlertLabels(context.Background(), "fp1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if labels["alertname"] != "HighCPU" || labels["severity"] != "warning" {
+		t.Errorf("unexpected labels: %+v", labels)
+	}
+}
+
+func TestGetAlertLabels_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, RequestTimeout: 2 * time.Second})
+	_, err := c.GetAlertLabels(context.Background(), "fp-missing")
+	if !errors.Is(err, ErrAlertNotFound) {
+		t.Errorf("expected ErrAlertNotFound, got %v", err)
+	}
+}
+
+func TestGetAlertLabels_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = io.WriteString(w, `boom`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, RequestTimeout: 2 * time.Second})
+	_, err := c.GetAlertLabels(context.Background(), "fp")
+	var ae *APIError
+	if !errors.As(err, &ae) || ae.StatusCode != 500 {
+		t.Errorf("expected APIError(500), got %v", err)
+	}
+}
+
+func TestCreateSilence_OK(t *testing.T) {
+	var got SilenceRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/silences" {
+			t.Errorf("path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method: %s", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		_, _ = io.WriteString(w, `{"silenceID":"s-123"}`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, RequestTimeout: 2 * time.Second})
+	id, err := c.CreateSilence(context.Background(), SilenceRequest{
+		Matchers:  []Matcher{{Name: "alertname", Value: "HighCPU", IsEqual: true}},
+		StartsAt:  time.Now(),
+		EndsAt:    time.Now().Add(time.Hour),
+		CreatedBy: "tester",
+		Comment:   "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "s-123" {
+		t.Errorf("silence id: %s", id)
+	}
+	if len(got.Matchers) != 1 || got.Matchers[0].Name != "alertname" {
+		t.Errorf("matchers: %+v", got.Matchers)
+	}
+}
+
+func TestCreateSilence_AMRejects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		_, _ = io.WriteString(w, `invalid matcher`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, RequestTimeout: 2 * time.Second})
+	_, err := c.CreateSilence(context.Background(), SilenceRequest{})
+	var ae *APIError
+	if !errors.As(err, &ae) || ae.StatusCode != 400 {
+		t.Errorf("expected APIError(400), got %v", err)
+	}
+}
+
+func TestAuth_Bearer(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, Auth: Auth{Token: "tkn"}, RequestTimeout: time.Second})
+	_, _ = c.GetAlertLabels(context.Background(), "fp")
+	if gotAuth != "Bearer tkn" {
+		t.Errorf("auth: %s", gotAuth)
+	}
+}
+
+func TestAuth_Basic(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, Auth: Auth{Username: "u", Password: "p"}, RequestTimeout: time.Second})
+	_, _ = c.GetAlertLabels(context.Background(), "fp")
+	if !strings.HasPrefix(gotAuth, "Basic ") {
+		t.Errorf("expected Basic auth, got %q", gotAuth)
+	}
+}
+
+func TestMatchersFromLabels(t *testing.T) {
+	m := MatchersFromLabels(map[string]string{"a": "1", "b": "2"})
+	if len(m) != 2 {
+		t.Fatalf("expected 2 matchers, got %d", len(m))
+	}
+	for _, x := range m {
+		if !x.IsEqual || x.IsRegex {
+			t.Errorf("matcher flags wrong: %+v", x)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,10 +16,12 @@ const (
 )
 
 type Config struct {
-	Server    Server            `yaml:"server"`
-	Telegram  Telegram          `yaml:"telegram"`
-	Templates map[string]string `yaml:"templates"`
-	Logging   Logging           `yaml:"logging"`
+	Server       Server            `yaml:"server"`
+	Telegram     Telegram          `yaml:"telegram"`
+	Templates    map[string]string `yaml:"templates"`
+	Logging      Logging           `yaml:"logging"`
+	Updates      Updates           `yaml:"updates"`
+	Alertmanager Alertmanager      `yaml:"alertmanager"`
 }
 
 type Server struct {
@@ -54,6 +56,30 @@ type Logging struct {
 	Format string `yaml:"format"`
 }
 
+type Updates struct {
+	Enabled          bool          `yaml:"enabled"`
+	PollTimeout      time.Duration `yaml:"poll_timeout"`
+	ChatAllowlist    []int64       `yaml:"chat_allowlist"`
+	UserAllowlist    []int64       `yaml:"user_allowlist"`
+	SilenceDurations []string      `yaml:"silence_durations"`
+	LabelCacheTTL    time.Duration `yaml:"label_cache_ttl"`
+	LabelCacheMax    int           `yaml:"label_cache_max"`
+	// ButtonTTL defines the window during which a user can press the silence
+	// buttons on an alert message. After this window the sweeper removes the
+	// inline keyboard and late clicks are rejected. Allowed range: 2h..48h.
+	ButtonTTL time.Duration `yaml:"button_ttl"`
+}
+
+const (
+	ButtonTTLMin = 2 * time.Hour
+	ButtonTTLMax = 48 * time.Hour
+)
+
+type Alertmanager struct {
+	URL            string        `yaml:"url"`
+	RequestTimeout time.Duration `yaml:"request_timeout"`
+}
+
 func Default() Config {
 	return Config{
 		Server: Server{
@@ -83,6 +109,20 @@ func Default() Config {
 		Logging: Logging{
 			Level:  "info",
 			Format: "json",
+		},
+		Updates: Updates{
+			Enabled:          false,
+			PollTimeout:      30 * time.Second,
+			ChatAllowlist:    nil,
+			UserAllowlist:    nil,
+			SilenceDurations: []string{"1h", "4h", "24h"},
+			LabelCacheTTL:    48 * time.Hour,
+			LabelCacheMax:    10000,
+			ButtonTTL:        8 * time.Hour,
+		},
+		Alertmanager: Alertmanager{
+			URL:            "",
+			RequestTimeout: 10 * time.Second,
 		},
 	}
 }
@@ -153,6 +193,35 @@ func (c Config) Validate() error {
 	case "json", "text":
 	default:
 		return fmt.Errorf("invalid logging.format %q", c.Logging.Format)
+	}
+	if c.Updates.Enabled {
+		if c.Updates.PollTimeout <= 0 {
+			return errors.New("updates.poll_timeout must be > 0 when updates.enabled is true")
+		}
+		if len(c.Updates.SilenceDurations) == 0 {
+			return errors.New("updates.silence_durations must have at least one entry when updates.enabled is true")
+		}
+		for _, d := range c.Updates.SilenceDurations {
+			if _, err := time.ParseDuration(d); err != nil {
+				return fmt.Errorf("updates.silence_durations: invalid duration %q: %w", d, err)
+			}
+		}
+		if c.Updates.LabelCacheTTL <= 0 {
+			return errors.New("updates.label_cache_ttl must be > 0 when updates.enabled is true")
+		}
+		if c.Updates.LabelCacheMax <= 0 {
+			return errors.New("updates.label_cache_max must be > 0 when updates.enabled is true")
+		}
+		if c.Alertmanager.URL == "" {
+			return errors.New("alertmanager.url is required when updates.enabled is true")
+		}
+		if c.Alertmanager.RequestTimeout <= 0 {
+			return errors.New("alertmanager.request_timeout must be > 0 when updates.enabled is true")
+		}
+		if c.Updates.ButtonTTL < ButtonTTLMin || c.Updates.ButtonTTL > ButtonTTLMax {
+			return fmt.Errorf("updates.button_ttl must be within %s..%s, got %s",
+				ButtonTTLMin, ButtonTTLMax, c.Updates.ButtonTTL)
+		}
 	}
 	return nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -22,6 +22,9 @@ var (
 	AuthFailures          prometheus.Counter
 	SourceParseDuration   *prometheus.HistogramVec
 	BuildInfo             *prometheus.GaugeVec
+	CallbacksReceived     *prometheus.CounterVec
+	SilencesCreated       *prometheus.CounterVec
+	UpdatesPollErrors     *prometheus.CounterVec
 )
 
 func Init() *prometheus.Registry {
@@ -80,6 +83,21 @@ func Init() *prometheus.Registry {
 			Help: "Build metadata. Always 1.",
 		}, []string{"version", "commit", "go_version"})
 
+		CallbacksReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "alertly_callbacks_received_total",
+			Help: "Number of Telegram callback_query events handled per action and outcome.",
+		}, []string{"action", "status"})
+
+		SilencesCreated = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "alertly_silences_created_total",
+			Help: "Number of Alertmanager silences created via callback, per outcome.",
+		}, []string{"status"})
+
+		UpdatesPollErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "alertly_updates_poll_errors_total",
+			Help: "Number of errors while long-polling Telegram getUpdates, per reason.",
+		}, []string{"reason"})
+
 		registry.MustRegister(
 			NotificationsReceived,
 			NotificationsSent,
@@ -91,6 +109,9 @@ func Init() *prometheus.Registry {
 			AuthFailures,
 			SourceParseDuration,
 			BuildInfo,
+			CallbacksReceived,
+			SilencesCreated,
+			UpdatesPollErrors,
 			collectors.NewGoCollector(),
 			collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		)

--- a/internal/server/button_tracker.go
+++ b/internal/server/button_tracker.go
@@ -101,7 +101,7 @@ func (t *ButtonTracker) Sweep() []ExpiredEntry {
 		if now.Before(e.ExpiresAt) {
 			continue
 		}
-		expired = append(expired, ExpiredEntry{ChatID: k.ChatID, MessageID: k.MessageID})
+		expired = append(expired, ExpiredEntry(k))
 		delete(t.entries, k)
 	}
 	return expired

--- a/internal/server/button_tracker.go
+++ b/internal/server/button_tracker.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/MaksimRudakov/alertly/internal/telegram"
+)
+
+// buttonKey identifies a message whose inline keyboard is under management.
+type buttonKey struct {
+	ChatID    int64
+	MessageID int64
+}
+
+type buttonEntry struct {
+	Fingerprint string
+	ExpiresAt   time.Time
+}
+
+// ButtonTracker tracks alert messages that carry silence buttons and expires
+// them after ButtonTTL. Tracker state is in-memory; an alertly restart causes
+// orphaned buttons to remain on screen, but callbacks for them will be
+// rejected because the tracker will not recognise them (strict policy).
+type ButtonTracker struct {
+	mu      sync.Mutex
+	entries map[buttonKey]buttonEntry
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+func NewButtonTracker(ttl time.Duration) *ButtonTracker {
+	return &ButtonTracker{
+		entries: make(map[buttonKey]buttonEntry),
+		ttl:     ttl,
+		now:     time.Now,
+	}
+}
+
+// Register records a sent message whose keyboard should live for TTL.
+func (t *ButtonTracker) Register(chatID, messageID int64, fingerprint string) {
+	if t == nil || messageID == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.entries[buttonKey{ChatID: chatID, MessageID: messageID}] = buttonEntry{
+		Fingerprint: fingerprint,
+		ExpiresAt:   t.now().Add(t.ttl),
+	}
+}
+
+// Valid reports whether a message is still within its silence window.
+// Returns false when the tracker is nil, the entry is missing (restart case),
+// or the entry has expired.
+func (t *ButtonTracker) Valid(chatID, messageID int64) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	entry, ok := t.entries[buttonKey{ChatID: chatID, MessageID: messageID}]
+	if !ok {
+		return false
+	}
+	return t.now().Before(entry.ExpiresAt)
+}
+
+// Consume removes an entry (typically called after a successful silence so the
+// sweeper does not re-edit an already-stripped message). Safe to call on
+// missing entries.
+func (t *ButtonTracker) Consume(chatID, messageID int64) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.entries, buttonKey{ChatID: chatID, MessageID: messageID})
+}
+
+// ExpiredEntry is returned from Sweep so callers can edit the corresponding
+// messages.
+type ExpiredEntry struct {
+	ChatID    int64
+	MessageID int64
+}
+
+// Sweep pops all entries whose TTL has elapsed and returns them. Callers
+// typically then call EditMessageReplyMarkup(nil) for each.
+func (t *ButtonTracker) Sweep() []ExpiredEntry {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	var expired []ExpiredEntry
+	for k, e := range t.entries {
+		if now.Before(e.ExpiresAt) {
+			continue
+		}
+		expired = append(expired, ExpiredEntry{ChatID: k.ChatID, MessageID: k.MessageID})
+		delete(t.entries, k)
+	}
+	return expired
+}
+
+// Len returns the current number of tracked messages (for metrics/debug).
+func (t *ButtonTracker) Len() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.entries)
+}
+
+// ButtonSweeper runs Sweep on a ticker and calls EditMessageReplyMarkup(nil)
+// for each expired message.
+type ButtonSweeper struct {
+	Tracker  *ButtonTracker
+	Telegram telegram.Client
+	Logger   *slog.Logger
+	Interval time.Duration
+}
+
+func (s *ButtonSweeper) Run(ctx context.Context) {
+	interval := s.Interval
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	s.Logger.Info("button sweeper started", "interval", interval)
+	defer s.Logger.Info("button sweeper stopped")
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sweepOnce(ctx)
+		}
+	}
+}
+
+func (s *ButtonSweeper) sweepOnce(ctx context.Context) {
+	expired := s.Tracker.Sweep()
+	if len(expired) == 0 {
+		return
+	}
+	for _, e := range expired {
+		// Per-edit timeout so a stuck call does not stall the whole sweep.
+		ectx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := s.Telegram.EditMessageReplyMarkup(ectx, e.ChatID, e.MessageID, nil); err != nil {
+			// Already-edited / message-not-found → log and move on; we already
+			// dropped the entry from the tracker, so no retry loop develops.
+			s.Logger.Warn("sweeper: edit reply markup failed",
+				"chat_id", e.ChatID, "message_id", e.MessageID, "err", err)
+		}
+		cancel()
+		if ctx.Err() != nil {
+			return
+		}
+	}
+	s.Logger.Debug("button sweeper pass", "expired", len(expired))
+}

--- a/internal/server/button_tracker_test.go
+++ b/internal/server/button_tracker_test.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MaksimRudakov/alertly/internal/telegram"
+)
+
+func TestButtonTracker_RegisterValid(t *testing.T) {
+	tr := NewButtonTracker(time.Hour)
+	tr.Register(-100, 42, "fp")
+	if !tr.Valid(-100, 42) {
+		t.Error("expected valid")
+	}
+	if tr.Valid(-100, 43) {
+		t.Error("different message_id must be invalid")
+	}
+	if tr.Valid(-999, 42) {
+		t.Error("different chat_id must be invalid")
+	}
+}
+
+func TestButtonTracker_RegisterZeroMessageIDIgnored(t *testing.T) {
+	tr := NewButtonTracker(time.Hour)
+	tr.Register(-100, 0, "fp")
+	if tr.Len() != 0 {
+		t.Error("message_id=0 must be ignored")
+	}
+}
+
+func TestButtonTracker_Expiry(t *testing.T) {
+	tr := NewButtonTracker(time.Hour)
+	now := time.Unix(0, 0)
+	tr.now = func() time.Time { return now }
+
+	tr.Register(-100, 42, "fp")
+	if !tr.Valid(-100, 42) {
+		t.Fatal("expected valid right after register")
+	}
+	now = now.Add(time.Hour + time.Second)
+	if tr.Valid(-100, 42) {
+		t.Error("expected expired after TTL elapses")
+	}
+}
+
+func TestButtonTracker_Sweep(t *testing.T) {
+	tr := NewButtonTracker(time.Hour)
+	now := time.Unix(0, 0)
+	tr.now = func() time.Time { return now }
+
+	tr.Register(-100, 1, "fp1")
+	tr.Register(-100, 2, "fp2")
+	now = now.Add(time.Hour)
+	tr.Register(-100, 3, "fp3") // expires 1h after the new "now"
+
+	now = now.Add(time.Second) // fp1, fp2 expired; fp3 still valid
+	expired := tr.Sweep()
+	if len(expired) != 2 {
+		t.Fatalf("expected 2 expired, got %d", len(expired))
+	}
+	// Sweep must remove them from the tracker.
+	if tr.Valid(-100, 1) || tr.Valid(-100, 2) {
+		t.Error("sweep must remove entries from tracker")
+	}
+	if !tr.Valid(-100, 3) {
+		t.Error("fp3 should remain")
+	}
+}
+
+func TestButtonTracker_Consume(t *testing.T) {
+	tr := NewButtonTracker(time.Hour)
+	tr.Register(-100, 42, "fp")
+	tr.Consume(-100, 42)
+	if tr.Valid(-100, 42) {
+		t.Error("consume must remove the entry")
+	}
+	// Idempotent:
+	tr.Consume(-100, 42)
+}
+
+func TestButtonTracker_NilSafe(t *testing.T) {
+	var tr *ButtonTracker
+	tr.Register(1, 1, "x")
+	if tr.Valid(1, 1) {
+		t.Error("nil tracker must always return invalid")
+	}
+	if len(tr.Sweep()) != 0 {
+		t.Error("nil Sweep must return empty slice")
+	}
+	if tr.Len() != 0 {
+		t.Error("nil Len must return 0")
+	}
+}
+
+// --- Sweeper tests ---------------------------------------------------------
+
+type sweepFakeTG struct {
+	mu       sync.Mutex
+	calls    []edit
+	editErr  error
+	sleep    time.Duration
+	finished atomic.Int32
+}
+
+func (f *sweepFakeTG) SendMessage(context.Context, int64, *int, string, *telegram.SendOptions) (int64, error) {
+	return 0, nil
+}
+func (f *sweepFakeTG) GetMe(context.Context) error { return nil }
+func (f *sweepFakeTG) GetUpdates(context.Context, int64, time.Duration) ([]telegram.Update, error) {
+	return nil, nil
+}
+func (f *sweepFakeTG) AnswerCallbackQuery(context.Context, string, string, bool) error { return nil }
+func (f *sweepFakeTG) EditMessageText(context.Context, int64, int64, string, *telegram.InlineKeyboardMarkup) error {
+	return nil
+}
+func (f *sweepFakeTG) EditMessageReplyMarkup(_ context.Context, chatID, messageID int64, m *telegram.InlineKeyboardMarkup) error {
+	if f.sleep > 0 {
+		time.Sleep(f.sleep)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, edit{ChatID: chatID, MessageID: messageID, Markup: m})
+	f.finished.Add(1)
+	return f.editErr
+}
+
+func TestButtonSweeper_EditsExpired(t *testing.T) {
+	tr := NewButtonTracker(time.Hour)
+	now := time.Unix(0, 0)
+	tr.now = func() time.Time { return now }
+	tr.Register(-100, 1, "fp1")
+	tr.Register(-100, 2, "fp2")
+	now = now.Add(time.Hour + time.Second)
+
+	tg := &sweepFakeTG{}
+	sw := &ButtonSweeper{
+		Tracker:  tr,
+		Telegram: tg,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Interval: time.Millisecond,
+	}
+	sw.sweepOnce(context.Background())
+	if got := tg.finished.Load(); got != 2 {
+		t.Errorf("expected 2 edits, got %d", got)
+	}
+	for _, e := range tg.calls {
+		if e.Markup != nil {
+			t.Errorf("sweeper must clear markup, got %+v", e.Markup)
+		}
+	}
+}
+
+func TestButtonSweeper_ContinuesOnEditError(t *testing.T) {
+	tr := NewButtonTracker(time.Hour)
+	now := time.Unix(0, 0)
+	tr.now = func() time.Time { return now }
+	tr.Register(-100, 1, "fp")
+	tr.Register(-100, 2, "fp")
+	now = now.Add(time.Hour + time.Second)
+
+	tg := &sweepFakeTG{editErr: errors.New("msg gone")}
+	sw := &ButtonSweeper{Tracker: tr, Telegram: tg, Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	sw.sweepOnce(context.Background())
+	if tg.finished.Load() != 2 {
+		t.Errorf("expected both edits attempted even on error, got %d", tg.finished.Load())
+	}
+	// Tracker must have dropped them regardless of edit outcome.
+	if tr.Len() != 0 {
+		t.Errorf("tracker must drop expired entries; Len=%d", tr.Len())
+	}
+}
+
+func TestButtonSweeper_Run_StopsOnCtxCancel(t *testing.T) {
+	tr := NewButtonTracker(time.Hour)
+	tg := &sweepFakeTG{}
+	sw := &ButtonSweeper{
+		Tracker:  tr,
+		Telegram: tg,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Interval: 10 * time.Millisecond,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { sw.Run(ctx); close(done) }()
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sweeper did not stop within 1s of cancel")
+	}
+}

--- a/internal/server/callback.go
+++ b/internal/server/callback.go
@@ -1,0 +1,219 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/MaksimRudakov/alertly/internal/alertmanager"
+	"github.com/MaksimRudakov/alertly/internal/metrics"
+	"github.com/MaksimRudakov/alertly/internal/telegram"
+)
+
+const (
+	CallbackActionSilence = "s"
+	callbackFieldSep      = "|"
+)
+
+// CallbackDeps carries dependencies for handling Telegram callback_query events.
+type CallbackDeps struct {
+	Logger        *slog.Logger
+	Telegram      telegram.Client
+	AM            alertmanager.Client
+	Cache         *alertmanager.LabelCache
+	Tracker       *ButtonTracker
+	ChatAllowlist []int64
+	UserAllowlist []int64
+	Durations     map[string]time.Duration // "1h" -> 1h, pre-validated at startup
+}
+
+// CallbackHandler processes a single callback_query: validates allowlists,
+// resolves labels, creates a silence, acks the callback, edits the message.
+type CallbackHandler struct {
+	deps CallbackDeps
+}
+
+func NewCallbackHandler(deps CallbackDeps) *CallbackHandler {
+	return &CallbackHandler{deps: deps}
+}
+
+// Handle processes one callback_query. Errors from this method are logged
+// but never propagated — the long-poll loop must keep running.
+func (h *CallbackHandler) Handle(ctx context.Context, cq *telegram.CallbackQuery) {
+	if cq == nil {
+		return
+	}
+	logger := h.deps.Logger.With(
+		"callback_id", cq.ID,
+		"user_id", cq.From.ID,
+		"username", cq.From.Username,
+	)
+	if cq.Message != nil {
+		logger = logger.With("chat_id", cq.Message.Chat.ID, "message_id", cq.Message.MessageID)
+	}
+
+	action, fingerprint, durationKey, err := ParseCallbackData(cq.Data)
+	if err != nil {
+		metrics.CallbacksReceived.WithLabelValues("unknown", "invalid").Inc()
+		logger.Warn("callback: invalid data", "data", cq.Data, "err", err)
+		h.answer(ctx, cq.ID, "⚠️ Invalid callback.", true)
+		return
+	}
+	logger = logger.With("action", action, "fingerprint", fingerprint, "duration", durationKey)
+
+	if action != CallbackActionSilence {
+		metrics.CallbacksReceived.WithLabelValues(action, "invalid").Inc()
+		logger.Warn("callback: unknown action")
+		h.answer(ctx, cq.ID, "⚠️ Unknown action.", true)
+		return
+	}
+
+	if cq.Message == nil {
+		metrics.CallbacksReceived.WithLabelValues(action, "invalid").Inc()
+		logger.Warn("callback: missing message")
+		h.answer(ctx, cq.ID, "⚠️ Missing message context.", true)
+		return
+	}
+
+	chatID := cq.Message.Chat.ID
+	if !int64InSet(chatID, h.deps.ChatAllowlist) {
+		metrics.CallbacksReceived.WithLabelValues(action, "auth_failed").Inc()
+		logger.Warn("callback: chat not in allowlist")
+		h.answer(ctx, cq.ID, "⛔ This chat cannot silence alerts.", true)
+		return
+	}
+	if len(h.deps.UserAllowlist) > 0 && !int64InSet(cq.From.ID, h.deps.UserAllowlist) {
+		metrics.CallbacksReceived.WithLabelValues(action, "auth_failed").Inc()
+		logger.Warn("callback: user not in allowlist")
+		h.answer(ctx, cq.ID, "⛔ You are not authorized to silence alerts.", true)
+		return
+	}
+
+	// Window check: strict — if the message is not tracked or has expired,
+	// reject the click and strip the keyboard so it is clear nothing will happen.
+	if !h.deps.Tracker.Valid(chatID, cq.Message.MessageID) {
+		metrics.CallbacksReceived.WithLabelValues(action, "expired").Inc()
+		logger.Warn("callback: silence window expired or unknown message")
+		h.stripKeyboard(ctx, cq)
+		h.answer(ctx, cq.ID, "⏰ Silence window expired for this alert.", true)
+		return
+	}
+
+	duration, ok := h.deps.Durations[durationKey]
+	if !ok {
+		metrics.CallbacksReceived.WithLabelValues(action, "invalid").Inc()
+		logger.Warn("callback: duration not configured", "duration", durationKey)
+		h.answer(ctx, cq.ID, "⚠️ Unsupported silence duration.", true)
+		return
+	}
+
+	labels, err := h.resolveLabels(ctx, fingerprint)
+	if err != nil {
+		if errors.Is(err, alertmanager.ErrAlertNotFound) {
+			metrics.CallbacksReceived.WithLabelValues(action, "not_found").Inc()
+			logger.Warn("callback: alert not found")
+			h.answer(ctx, cq.ID, "⚠️ Alert no longer active and not in cache.", true)
+			return
+		}
+		metrics.CallbacksReceived.WithLabelValues(action, "am_error").Inc()
+		logger.Error("callback: resolve labels failed", "err", err)
+		h.answer(ctx, cq.ID, "⚠️ Failed to query Alertmanager.", true)
+		return
+	}
+
+	now := time.Now().UTC()
+	silenceID, err := h.deps.AM.CreateSilence(ctx, alertmanager.SilenceRequest{
+		Matchers:  alertmanager.MatchersFromLabels(labels),
+		StartsAt:  now,
+		EndsAt:    now.Add(duration),
+		CreatedBy: silenceCreatedBy(cq.From),
+		Comment:   fmt.Sprintf("silenced via alertly by %s from chat %d", silenceCreatedBy(cq.From), chatID),
+	})
+	if err != nil {
+		metrics.CallbacksReceived.WithLabelValues(action, "am_error").Inc()
+		metrics.SilencesCreated.WithLabelValues("error").Inc()
+		logger.Error("callback: create silence failed", "err", err)
+		h.answer(ctx, cq.ID, "⚠️ Alertmanager rejected the silence.", true)
+		return
+	}
+
+	metrics.CallbacksReceived.WithLabelValues(action, "ok").Inc()
+	metrics.SilencesCreated.WithLabelValues("ok").Inc()
+	logger.Info("silence created", "silence_id", silenceID, "until", now.Add(duration))
+
+	// Strip buttons so nobody silences twice from the same alert.
+	h.stripKeyboard(ctx, cq)
+	h.deps.Tracker.Consume(chatID, cq.Message.MessageID)
+	until := now.Add(duration).Format("15:04 MST")
+	h.answer(ctx, cq.ID, fmt.Sprintf("🔇 Silenced %s until %s (id: %s)", durationKey, until, silenceID), false)
+}
+
+func (h *CallbackHandler) resolveLabels(ctx context.Context, fingerprint string) (map[string]string, error) {
+	labels, err := h.deps.AM.GetAlertLabels(ctx, fingerprint)
+	if err == nil {
+		return labels, nil
+	}
+	if errors.Is(err, alertmanager.ErrAlertNotFound) {
+		if cached, ok := h.deps.Cache.Get(fingerprint); ok {
+			return cached, nil
+		}
+		return nil, alertmanager.ErrAlertNotFound
+	}
+	return nil, err
+}
+
+func (h *CallbackHandler) stripKeyboard(ctx context.Context, cq *telegram.CallbackQuery) {
+	if cq.Message == nil {
+		return
+	}
+	if err := h.deps.Telegram.EditMessageReplyMarkup(ctx, cq.Message.Chat.ID, cq.Message.MessageID, nil); err != nil {
+		h.deps.Logger.Warn("callback: edit reply markup failed", "err", err)
+	}
+}
+
+func (h *CallbackHandler) answer(ctx context.Context, id, text string, showAlert bool) {
+	// Answer must be sent within ~15s or Telegram shows "loading…". Use a short,
+	// context-bounded timeout so a stuck AM does not block the ack.
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := h.deps.Telegram.AnswerCallbackQuery(cctx, id, text, showAlert); err != nil {
+		h.deps.Logger.Warn("answerCallbackQuery failed", "err", err)
+	}
+}
+
+// ParseCallbackData parses "s|<fp>|<dur>" into its parts.
+func ParseCallbackData(data string) (action, fingerprint, durationKey string, err error) {
+	parts := strings.Split(data, callbackFieldSep)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("expected 3 fields, got %d", len(parts))
+	}
+	if parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", errors.New("empty field in callback data")
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+// BuildCallbackData assembles "s|<fp>|<dur>". Caller is responsible for keeping
+// the result <=64 bytes (Telegram limit).
+func BuildCallbackData(action, fingerprint, durationKey string) string {
+	return action + callbackFieldSep + fingerprint + callbackFieldSep + durationKey
+}
+
+func int64InSet(v int64, set []int64) bool {
+	for _, x := range set {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func silenceCreatedBy(u telegram.User) string {
+	if u.Username != "" {
+		return "telegram:@" + u.Username
+	}
+	return fmt.Sprintf("telegram:%d", u.ID)
+}

--- a/internal/server/callback_test.go
+++ b/internal/server/callback_test.go
@@ -1,0 +1,378 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MaksimRudakov/alertly/internal/alertmanager"
+	"github.com/MaksimRudakov/alertly/internal/metrics"
+	"github.com/MaksimRudakov/alertly/internal/telegram"
+)
+
+func init() {
+	metrics.Init()
+}
+
+func TestParseCallbackData(t *testing.T) {
+	cases := []struct {
+		in         string
+		wantAct    string
+		wantFP     string
+		wantDur    string
+		wantErr    bool
+		descripion string
+	}{
+		{"s|abc|1h", "s", "abc", "1h", false, "normal"},
+		{"s|9bcf23a1e4d08b17|24h", "s", "9bcf23a1e4d08b17", "24h", false, "fp16"},
+		{"s|abc", "", "", "", true, "too few fields"},
+		{"s|abc|1h|extra", "", "", "", true, "too many fields"},
+		{"|abc|1h", "", "", "", true, "empty action"},
+		{"s||1h", "", "", "", true, "empty fp"},
+		{"s|abc|", "", "", "", true, "empty duration"},
+		{"", "", "", "", true, "empty"},
+	}
+	for _, c := range cases {
+		t.Run(c.descripion, func(t *testing.T) {
+			act, fp, dur, err := ParseCallbackData(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", c.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if act != c.wantAct || fp != c.wantFP || dur != c.wantDur {
+				t.Errorf("got (%q,%q,%q), want (%q,%q,%q)", act, fp, dur, c.wantAct, c.wantFP, c.wantDur)
+			}
+		})
+	}
+}
+
+func TestBuildCallbackDataSize(t *testing.T) {
+	// sha256-16 fingerprint + typical duration — must stay within 64 bytes.
+	data := BuildCallbackData(CallbackActionSilence, "9bcf23a1e4d08b17", "24h")
+	if len(data) > 64 {
+		t.Errorf("callback_data too long: %d bytes", len(data))
+	}
+}
+
+// --- fake telegram client --------------------------------------------------
+
+type fakeTG struct {
+	mu              sync.Mutex
+	answers         []answer
+	editedMarkups   []edit
+	editedTexts     []edit
+	sendErr         error
+	answerErr       error
+	editReplyErr    error
+	editTextErr     error
+	callbacksCalled int
+}
+
+type answer struct {
+	ID        string
+	Text      string
+	ShowAlert bool
+}
+type edit struct {
+	ChatID    int64
+	MessageID int64
+	Text      string
+	Markup    *telegram.InlineKeyboardMarkup
+}
+
+func (f *fakeTG) SendMessage(context.Context, int64, *int, string, *telegram.SendOptions) (int64, error) {
+	return 0, f.sendErr
+}
+func (f *fakeTG) GetMe(context.Context) error { return nil }
+func (f *fakeTG) GetUpdates(context.Context, int64, time.Duration) ([]telegram.Update, error) {
+	return nil, nil
+}
+func (f *fakeTG) AnswerCallbackQuery(_ context.Context, id, text string, showAlert bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.callbacksCalled++
+	f.answers = append(f.answers, answer{ID: id, Text: text, ShowAlert: showAlert})
+	return f.answerErr
+}
+func (f *fakeTG) EditMessageText(_ context.Context, chatID, messageID int64, text string, m *telegram.InlineKeyboardMarkup) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.editedTexts = append(f.editedTexts, edit{ChatID: chatID, MessageID: messageID, Text: text, Markup: m})
+	return f.editTextErr
+}
+func (f *fakeTG) EditMessageReplyMarkup(_ context.Context, chatID, messageID int64, m *telegram.InlineKeyboardMarkup) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.editedMarkups = append(f.editedMarkups, edit{ChatID: chatID, MessageID: messageID, Markup: m})
+	return f.editReplyErr
+}
+
+// --- fake AM client --------------------------------------------------------
+
+type fakeAM struct {
+	labels        map[string]map[string]string
+	getErr        error
+	silenceErr    error
+	silenceID     string
+	createdReqs   []alertmanager.SilenceRequest
+	mu            sync.Mutex
+	getAlertCalls int
+}
+
+func (f *fakeAM) GetAlertLabels(_ context.Context, fp string) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getAlertCalls++
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	l, ok := f.labels[fp]
+	if !ok {
+		return nil, alertmanager.ErrAlertNotFound
+	}
+	return l, nil
+}
+
+func (f *fakeAM) CreateSilence(_ context.Context, req alertmanager.SilenceRequest) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createdReqs = append(f.createdReqs, req)
+	if f.silenceErr != nil {
+		return "", f.silenceErr
+	}
+	if f.silenceID == "" {
+		return "silence-1", nil
+	}
+	return f.silenceID, nil
+}
+
+// --- tests -----------------------------------------------------------------
+
+func newHandler(tg *fakeTG, am *fakeAM, cache *alertmanager.LabelCache, chats, users []int64) *CallbackHandler {
+	// Tracker keys by (chat_id, message_id); the fingerprint stored here does
+	// not need to match the one in callback_data.
+	tracker := NewButtonTracker(time.Hour)
+	tracker.Register(-100, 42, "any")
+	return NewCallbackHandler(CallbackDeps{
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Telegram:      tg,
+		AM:            am,
+		Cache:         cache,
+		Tracker:       tracker,
+		ChatAllowlist: chats,
+		UserAllowlist: users,
+		Durations:     map[string]time.Duration{"1h": time.Hour, "24h": 24 * time.Hour},
+	})
+}
+
+func mkCallback(data string, chatID int64, userID int64) *telegram.CallbackQuery {
+	return &telegram.CallbackQuery{
+		ID:      "cbid",
+		From:    telegram.User{ID: userID, Username: "alice"},
+		Message: &telegram.Message{MessageID: 42, Chat: telegram.Chat{ID: chatID}},
+		Data:    data,
+	}
+}
+
+func TestCallback_HappyPath_AMHasLabels(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{labels: map[string]map[string]string{
+		"fp1": {"alertname": "X", "severity": "warning"},
+	}}
+	cache := alertmanager.NewLabelCache(time.Hour, 10)
+	h := newHandler(tg, am, cache, []int64{-100}, nil)
+
+	h.Handle(context.Background(), mkCallback("s|fp1|1h", -100, 1))
+
+	if len(am.createdReqs) != 1 {
+		t.Fatalf("expected 1 silence, got %d", len(am.createdReqs))
+	}
+	if len(am.createdReqs[0].Matchers) != 2 {
+		t.Errorf("matchers: %+v", am.createdReqs[0].Matchers)
+	}
+	if len(tg.editedMarkups) != 1 || tg.editedMarkups[0].Markup != nil {
+		t.Errorf("expected markup stripped, got %+v", tg.editedMarkups)
+	}
+	if len(tg.answers) != 1 || tg.answers[0].ShowAlert {
+		t.Errorf("answer: %+v", tg.answers)
+	}
+}
+
+func TestCallback_FallbackToCache(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{labels: map[string]map[string]string{}} // empty → not found
+	cache := alertmanager.NewLabelCache(time.Hour, 10)
+	cache.Put("fp-resolved", map[string]string{"alertname": "Gone"})
+	h := newHandler(tg, am, cache, []int64{-100}, nil)
+
+	h.Handle(context.Background(), mkCallback("s|fp-resolved|1h", -100, 1))
+
+	if len(am.createdReqs) != 1 {
+		t.Errorf("expected silence from cached labels, got %d", len(am.createdReqs))
+	}
+}
+
+func TestCallback_RejectsUnlistedChat(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{labels: map[string]map[string]string{"fp": {"a": "1"}}}
+	h := newHandler(tg, am, nil, []int64{-100}, nil)
+
+	h.Handle(context.Background(), mkCallback("s|fp|1h", -999, 1))
+
+	if len(am.createdReqs) != 0 {
+		t.Error("silence must not be created from unlisted chat")
+	}
+	if len(tg.answers) != 1 || !tg.answers[0].ShowAlert {
+		t.Errorf("expected show_alert answer, got %+v", tg.answers)
+	}
+}
+
+func TestCallback_RejectsUnlistedUser(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{labels: map[string]map[string]string{"fp": {"a": "1"}}}
+	h := newHandler(tg, am, nil, []int64{-100}, []int64{999})
+
+	h.Handle(context.Background(), mkCallback("s|fp|1h", -100, 1))
+
+	if len(am.createdReqs) != 0 {
+		t.Error("silence must not be created for unlisted user")
+	}
+}
+
+func TestCallback_InvalidDuration(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{labels: map[string]map[string]string{"fp": {"a": "1"}}}
+	h := newHandler(tg, am, nil, []int64{-100}, nil)
+
+	h.Handle(context.Background(), mkCallback("s|fp|99h", -100, 1))
+
+	if len(am.createdReqs) != 0 {
+		t.Error("unsupported duration must not create silence")
+	}
+	if tg.answers[0].Text != "⚠️ Unsupported silence duration." {
+		t.Errorf("answer: %+v", tg.answers[0])
+	}
+}
+
+func TestCallback_AlertNotFound(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{labels: map[string]map[string]string{}}
+	cache := alertmanager.NewLabelCache(time.Hour, 10)
+	h := newHandler(tg, am, cache, []int64{-100}, nil)
+
+	h.Handle(context.Background(), mkCallback("s|fp-unknown|1h", -100, 1))
+
+	if len(am.createdReqs) != 0 {
+		t.Error("silence must not be created when alert is unknown")
+	}
+}
+
+func TestCallback_AMErrorPropagates(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{
+		labels: map[string]map[string]string{"fp": {"a": "1"}},
+		silenceErr: &alertmanager.APIError{
+			StatusCode: 400, Body: "bad matcher",
+		},
+	}
+	h := newHandler(tg, am, nil, []int64{-100}, nil)
+
+	h.Handle(context.Background(), mkCallback("s|fp|1h", -100, 1))
+
+	if len(tg.editedMarkups) != 0 {
+		t.Error("markup must not be stripped when silence failed")
+	}
+	if len(tg.answers) != 1 || !tg.answers[0].ShowAlert {
+		t.Error("expected error answer with show_alert")
+	}
+}
+
+func TestCallback_GetLabelsErrorPropagates(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{getErr: errors.New("boom")}
+	h := newHandler(tg, am, nil, []int64{-100}, nil)
+	h.Handle(context.Background(), mkCallback("s|fp|1h", -100, 1))
+	if len(am.createdReqs) != 0 {
+		t.Error("silence must not be created if GetAlertLabels errors")
+	}
+}
+
+func TestCallback_InvalidDataNoSilence(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{}
+	h := newHandler(tg, am, nil, []int64{-100}, nil)
+	h.Handle(context.Background(), mkCallback("garbage", -100, 1))
+	if len(am.createdReqs) != 0 {
+		t.Error("silence must not be created for invalid data")
+	}
+	if am.getAlertCalls != 0 {
+		t.Error("AM must not be queried for invalid data")
+	}
+}
+
+func TestCallback_ExpiredWindow(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{labels: map[string]map[string]string{"fp": {"a": "1"}}}
+	// Build a handler with an empty tracker — simulating expired / unknown message.
+	tracker := NewButtonTracker(time.Hour)
+	h := NewCallbackHandler(CallbackDeps{
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Telegram:      tg,
+		AM:            am,
+		Cache:         alertmanager.NewLabelCache(time.Hour, 10),
+		Tracker:       tracker,
+		ChatAllowlist: []int64{-100},
+		Durations:     map[string]time.Duration{"1h": time.Hour},
+	})
+	h.Handle(context.Background(), mkCallback("s|fp|1h", -100, 1))
+
+	if len(am.createdReqs) != 0 {
+		t.Error("expired window must not create silence")
+	}
+	if len(tg.editedMarkups) != 1 || tg.editedMarkups[0].Markup != nil {
+		t.Errorf("expected keyboard strip, got %+v", tg.editedMarkups)
+	}
+	if len(tg.answers) != 1 || !tg.answers[0].ShowAlert {
+		t.Error("expected show_alert toast")
+	}
+}
+
+func TestCallback_ConsumeOnSuccess(t *testing.T) {
+	tg := &fakeTG{}
+	am := &fakeAM{labels: map[string]map[string]string{"fp": {"a": "1"}}}
+	tracker := NewButtonTracker(time.Hour)
+	tracker.Register(-100, 42, "fp")
+
+	h := NewCallbackHandler(CallbackDeps{
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Telegram:      tg,
+		AM:            am,
+		Cache:         alertmanager.NewLabelCache(time.Hour, 10),
+		Tracker:       tracker,
+		ChatAllowlist: []int64{-100},
+		Durations:     map[string]time.Duration{"1h": time.Hour},
+	})
+	h.Handle(context.Background(), mkCallback("s|fp|1h", -100, 1))
+
+	if tracker.Valid(-100, 42) {
+		t.Error("tracker entry must be consumed after successful silence")
+	}
+}
+
+func TestSilenceCreatedBy(t *testing.T) {
+	if got := silenceCreatedBy(telegram.User{ID: 5, Username: "bob"}); got != "telegram:@bob" {
+		t.Errorf("with username: %q", got)
+	}
+	if got := silenceCreatedBy(telegram.User{ID: 5}); got != "telegram:5" {
+		t.Errorf("without username: %q", got)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -23,6 +23,28 @@ type webhookDeps struct {
 	readiness    ReadinessTracker
 	maxBodyBytes int64
 	templateName string
+	keyboard     KeyboardBuilder
+	tracker      ButtonRegistrar
+}
+
+// ButtonRegistrar records sent alert messages so the callback handler can
+// validate and the sweeper can expire them. The handler only needs Register;
+// the full ButtonTracker also exposes Valid/Sweep for consumers.
+type ButtonRegistrar interface {
+	Register(chatID, messageID int64, fingerprint string)
+}
+
+// KeyboardBuilder returns an inline keyboard for a given chat + notification,
+// or nil if no keyboard should be attached. Always safe to return nil.
+type KeyboardBuilder interface {
+	Build(target notification.ChatTarget, n notification.Notification, sourceName string) *telegram.SendOptions
+}
+
+func (d webhookDeps) keyboardFor(target notification.ChatTarget, n notification.Notification) *telegram.SendOptions {
+	if d.keyboard == nil {
+		return nil
+	}
+	return d.keyboard.Build(target, n, d.source.Name())
 }
 
 func webhookHandler(d webhookDeps) http.HandlerFunc {
@@ -77,9 +99,17 @@ func webhookHandler(d webhookDeps) http.HandlerFunc {
 			}
 
 			for _, target := range targets {
-				for _, part := range parts {
+				for idx, part := range parts {
 					totalAttempts++
-					if err := d.send(ctx, target, part); err != nil {
+					var opts *telegram.SendOptions
+					// Attach inline keyboard only to the last message part, so buttons
+					// are attached once per (notification, chat) pair.
+					isLastPart := idx == len(parts)-1
+					if isLastPart {
+						opts = d.keyboardFor(target, n)
+					}
+					messageID, err := d.send(ctx, target, part, opts)
+					if err != nil {
 						totalErrors++
 						logger.Error("send failed",
 							"chat_id", target.ChatID,
@@ -91,6 +121,9 @@ func webhookHandler(d webhookDeps) http.HandlerFunc {
 						continue
 					}
 					metrics.NotificationsSent.WithLabelValues(strconv.FormatInt(target.ChatID, 10), "ok").Inc()
+					if isLastPart && opts != nil && d.tracker != nil && messageID != 0 {
+						d.tracker.Register(target.ChatID, messageID, n.Fingerprint)
+					}
 				}
 			}
 		}
@@ -115,14 +148,14 @@ func webhookHandler(d webhookDeps) http.HandlerFunc {
 	}
 }
 
-func (d webhookDeps) send(ctx context.Context, target notification.ChatTarget, text string) error {
-	err := d.tg.SendMessage(ctx, target.ChatID, target.ThreadID, text)
+func (d webhookDeps) send(ctx context.Context, target notification.ChatTarget, text string, opts *telegram.SendOptions) (int64, error) {
+	messageID, err := d.tg.SendMessage(ctx, target.ChatID, target.ThreadID, text, opts)
 	if err == nil {
 		d.readiness.RecordSendSuccess()
-		return nil
+		return messageID, nil
 	}
 	d.readiness.RecordSendFailure(isServerError(err))
-	return err
+	return 0, err
 }
 
 func isServerError(err error) bool {

--- a/internal/server/keyboard.go
+++ b/internal/server/keyboard.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"github.com/MaksimRudakov/alertly/internal/alertmanager"
+	"github.com/MaksimRudakov/alertly/internal/notification"
+	"github.com/MaksimRudakov/alertly/internal/telegram"
+)
+
+// AlertmanagerKeyboard attaches a single row of silence buttons to firing
+// alertmanager notifications in allowlisted chats. It also populates the label
+// cache so callbacks can resolve labels even if AM no longer has the alert.
+type AlertmanagerKeyboard struct {
+	Durations     []string // ordered, e.g. ["1h", "4h", "24h"]
+	ChatAllowlist []int64
+	Cache         *alertmanager.LabelCache
+}
+
+func (k *AlertmanagerKeyboard) Build(target notification.ChatTarget, n notification.Notification, sourceName string) *telegram.SendOptions {
+	if k == nil || sourceName != "alertmanager" {
+		return nil
+	}
+	if n.Status != "firing" || n.Fingerprint == "" {
+		return nil
+	}
+	if !int64InSet(target.ChatID, k.ChatAllowlist) {
+		return nil
+	}
+
+	// Cache labels on the way out so the callback handler has a fallback if AM
+	// already forgot about the alert. Happens per target, but Put is idempotent.
+	k.Cache.Put(n.Fingerprint, n.Labels)
+
+	silenceRow := make([]telegram.InlineKeyboardButton, 0, len(k.Durations))
+	for _, d := range k.Durations {
+		silenceRow = append(silenceRow, telegram.InlineKeyboardButton{
+			Text:         "🔇 Silence " + d,
+			CallbackData: BuildCallbackData(CallbackActionSilence, n.Fingerprint, d),
+		})
+	}
+	return &telegram.SendOptions{
+		ReplyMarkup: &telegram.InlineKeyboardMarkup{
+			InlineKeyboard: [][]telegram.InlineKeyboardButton{silenceRow},
+		},
+	}
+}

--- a/internal/server/keyboard_test.go
+++ b/internal/server/keyboard_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MaksimRudakov/alertly/internal/alertmanager"
+	"github.com/MaksimRudakov/alertly/internal/notification"
+)
+
+func TestKeyboard_FiringAllowlistedChat(t *testing.T) {
+	cache := alertmanager.NewLabelCache(time.Hour, 10)
+	k := &AlertmanagerKeyboard{
+		Durations:     []string{"1h", "4h"},
+		ChatAllowlist: []int64{-100},
+		Cache:         cache,
+	}
+	opts := k.Build(
+		notification.ChatTarget{ChatID: -100},
+		notification.Notification{
+			Status:      "firing",
+			Fingerprint: "fp",
+			Labels:      map[string]string{"a": "1"},
+			Links:       []notification.Link{{Title: "Runbook", URL: "https://rb"}},
+		},
+		"alertmanager",
+	)
+	if opts == nil || opts.ReplyMarkup == nil {
+		t.Fatal("expected keyboard")
+	}
+	rows := opts.ReplyMarkup.InlineKeyboard
+	if len(rows) != 1 {
+		t.Fatalf("expected single silence row, got %d", len(rows))
+	}
+	if len(rows[0]) != 2 {
+		t.Errorf("silence row length: %d", len(rows[0]))
+	}
+	if rows[0][0].CallbackData != "s|fp|1h" {
+		t.Errorf("callback_data: %s", rows[0][0].CallbackData)
+	}
+	for _, b := range rows[0] {
+		if b.URL != "" {
+			t.Errorf("URL button leaked into silence row: %+v", b)
+		}
+	}
+	if _, ok := cache.Get("fp"); !ok {
+		t.Error("labels should be cached on keyboard build")
+	}
+}
+
+func TestKeyboard_SuppressedForResolved(t *testing.T) {
+	k := &AlertmanagerKeyboard{
+		Durations:     []string{"1h"},
+		ChatAllowlist: []int64{-100},
+		Cache:         alertmanager.NewLabelCache(time.Hour, 10),
+	}
+	if opts := k.Build(
+		notification.ChatTarget{ChatID: -100},
+		notification.Notification{Status: "resolved", Fingerprint: "fp"},
+		"alertmanager",
+	); opts != nil {
+		t.Error("resolved alerts should not get silence buttons")
+	}
+}
+
+func TestKeyboard_SuppressedForUnlistedChat(t *testing.T) {
+	k := &AlertmanagerKeyboard{
+		Durations:     []string{"1h"},
+		ChatAllowlist: []int64{-100},
+		Cache:         alertmanager.NewLabelCache(time.Hour, 10),
+	}
+	if opts := k.Build(
+		notification.ChatTarget{ChatID: -999},
+		notification.Notification{Status: "firing", Fingerprint: "fp"},
+		"alertmanager",
+	); opts != nil {
+		t.Error("unlisted chat should not get buttons")
+	}
+}
+
+func TestKeyboard_SuppressedForOtherSource(t *testing.T) {
+	k := &AlertmanagerKeyboard{
+		Durations:     []string{"1h"},
+		ChatAllowlist: []int64{-100},
+		Cache:         alertmanager.NewLabelCache(time.Hour, 10),
+	}
+	if opts := k.Build(
+		notification.ChatTarget{ChatID: -100},
+		notification.Notification{Status: "firing", Fingerprint: "fp"},
+		"kubewatch",
+	); opts != nil {
+		t.Error("non-alertmanager source should not get silence buttons")
+	}
+}
+
+func TestKeyboard_SuppressedWhenFingerprintEmpty(t *testing.T) {
+	k := &AlertmanagerKeyboard{
+		Durations:     []string{"1h"},
+		ChatAllowlist: []int64{-100},
+		Cache:         alertmanager.NewLabelCache(time.Hour, 10),
+	}
+	if opts := k.Build(
+		notification.ChatTarget{ChatID: -100},
+		notification.Notification{Status: "firing"},
+		"alertmanager",
+	); opts != nil {
+		t.Error("empty fingerprint should not get buttons")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,6 +33,8 @@ type Deps struct {
 	Readiness ReadinessTracker
 	AuthToken string
 	Registry  *prometheus.Registry
+	Keyboard  KeyboardBuilder
+	Tracker   ButtonRegistrar
 }
 
 func New(cfg config.Server, deps Deps) *Server {
@@ -57,6 +59,8 @@ func New(cfg config.Server, deps Deps) *Server {
 			readiness:    deps.Readiness,
 			maxBodyBytes: cfg.MaxBodyBytes,
 			templateName: name,
+			keyboard:     deps.Keyboard,
+			tracker:      deps.Tracker,
 		})
 		mux.Handle(fmt.Sprintf("POST /v1/%s/{chats}", name), auth(h))
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -76,7 +76,7 @@ func newTelegramRecorderWith(t *testing.T, override func(chatID int64) (int, str
 					return
 				}
 			}
-			_, _ = io.WriteString(w, `{"ok":true}`)
+			_, _ = io.WriteString(w, `{"ok":true,"result":{"message_id":1}}`)
 		default:
 			http.NotFound(w, req)
 		}

--- a/internal/server/updates.go
+++ b/internal/server/updates.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/MaksimRudakov/alertly/internal/metrics"
+	"github.com/MaksimRudakov/alertly/internal/telegram"
+)
+
+// UpdatesPoller runs a long-poll loop against Telegram getUpdates and
+// dispatches callback_query events to a CallbackHandler. It exits cleanly
+// on context cancellation.
+type UpdatesPoller struct {
+	Client      telegram.Client
+	Handler     *CallbackHandler
+	Logger      *slog.Logger
+	PollTimeout time.Duration
+
+	offset int64
+}
+
+func (p *UpdatesPoller) Run(ctx context.Context) {
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+
+	p.Logger.Info("telegram updates poller started", "poll_timeout", p.PollTimeout)
+	defer p.Logger.Info("telegram updates poller stopped")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		pollCtx, cancel := context.WithTimeout(ctx, p.PollTimeout+30*time.Second)
+		updates, err := p.Client.GetUpdates(pollCtx, p.offset, p.PollTimeout)
+		cancel()
+
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			reason := "network"
+			if ae, ok := asTelegramAPIError(err); ok {
+				reason = "api_" + httpStatusClass(ae.Status())
+			}
+			metrics.UpdatesPollErrors.WithLabelValues(reason).Inc()
+			p.Logger.Warn("getUpdates failed", "err", err, "backoff", backoff)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			if backoff < maxBackoff {
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+			continue
+		}
+		backoff = time.Second
+
+		for _, u := range updates {
+			if u.UpdateID >= p.offset {
+				p.offset = u.UpdateID + 1
+			}
+			if u.CallbackQuery == nil {
+				continue
+			}
+			// Process each callback in the foreground; AM calls are quick and
+			// serialisation gives predictable ordering without extra locking.
+			p.Handler.Handle(ctx, u.CallbackQuery)
+		}
+	}
+}
+
+func asTelegramAPIError(err error) (*telegram.APIError, bool) {
+	if err == nil {
+		return nil, false
+	}
+	type unwrapper interface{ Unwrap() error }
+	for e := err; e != nil; {
+		if ae, ok := e.(*telegram.APIError); ok {
+			return ae, true
+		}
+		u, ok := e.(unwrapper)
+		if !ok {
+			return nil, false
+		}
+		e = u.Unwrap()
+	}
+	return nil, false
+}
+
+func httpStatusClass(code int) string {
+	switch {
+	case code == 429:
+		return "429"
+	case code >= 500:
+		return "5xx"
+	case code >= 400:
+		return "4xx"
+	default:
+		return "other"
+	}
+}

--- a/internal/server/updates_test.go
+++ b/internal/server/updates_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MaksimRudakov/alertly/internal/alertmanager"
+	"github.com/MaksimRudakov/alertly/internal/telegram"
+)
+
+func TestUpdatesPoller_DispatchesCallback(t *testing.T) {
+	var getUpdatesCalls atomic.Int32
+	var answerCalls atomic.Int32
+	var silenceCalls atomic.Int32
+
+	tgSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/getUpdates"):
+			n := getUpdatesCalls.Add(1)
+			if n == 1 {
+				_, _ = io.WriteString(w, `{"ok":true,"result":[{"update_id":1,"callback_query":{"id":"cb1","from":{"id":42,"username":"bob"},"message":{"message_id":7,"chat":{"id":-100}},"data":"s|fp1|1h"}}]}`)
+				return
+			}
+			// Subsequent polls return empty until timeout; short-circuit with empty.
+			_, _ = io.WriteString(w, `{"ok":true,"result":[]}`)
+		case strings.HasSuffix(r.URL.Path, "/answerCallbackQuery"):
+			answerCalls.Add(1)
+			_, _ = io.WriteString(w, `{"ok":true,"result":true}`)
+		case strings.HasSuffix(r.URL.Path, "/editMessageReplyMarkup"):
+			_, _ = io.WriteString(w, `{"ok":true,"result":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer tgSrv.Close()
+
+	amSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/alerts":
+			_, _ = io.WriteString(w, `[{"fingerprint":"fp1","labels":{"alertname":"X"}}]`)
+		case "/api/v2/silences":
+			silenceCalls.Add(1)
+			var req alertmanager.SilenceRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			_, _ = io.WriteString(w, `{"silenceID":"sil-1"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer amSrv.Close()
+
+	limiter := telegram.NewLimiter(1000, 1000)
+	tg := telegram.New(telegram.Config{
+		APIURL:         tgSrv.URL,
+		Token:          "t",
+		RequestTimeout: 2 * time.Second,
+		MaxAttempts:    1,
+	}, limiter, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	am := alertmanager.New(alertmanager.Config{URL: amSrv.URL, RequestTimeout: 2 * time.Second})
+	cache := alertmanager.NewLabelCache(time.Hour, 10)
+	tracker := NewButtonTracker(time.Hour)
+	// Register the message that the fake Telegram server sends in the callback.
+	tracker.Register(-100, 7, "fp1")
+	handler := NewCallbackHandler(CallbackDeps{
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Telegram:      tg,
+		AM:            am,
+		Cache:         cache,
+		Tracker:       tracker,
+		ChatAllowlist: []int64{-100},
+		Durations:     map[string]time.Duration{"1h": time.Hour},
+	})
+
+	poller := &UpdatesPoller{
+		Client:      tg,
+		Handler:     handler,
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		PollTimeout: 100 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { poller.Run(ctx); close(done) }()
+
+	// Wait for silence to be created via callback dispatch.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if silenceCalls.Load() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if silenceCalls.Load() < 1 {
+		t.Fatalf("expected silence to be created, got %d", silenceCalls.Load())
+	}
+	if answerCalls.Load() < 1 {
+		t.Fatalf("expected callback to be answered, got %d", answerCalls.Load())
+	}
+}
+
+func TestUpdatesPoller_ShutdownOnCtxCancel(t *testing.T) {
+	tgSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate slow poll; return empty after 50ms so the poller can loop.
+		time.Sleep(50 * time.Millisecond)
+		_, _ = io.WriteString(w, `{"ok":true,"result":[]}`)
+	}))
+	defer tgSrv.Close()
+
+	tg := telegram.New(telegram.Config{APIURL: tgSrv.URL, Token: "t", RequestTimeout: time.Second, MaxAttempts: 1},
+		telegram.NewLimiter(1000, 1000), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler := NewCallbackHandler(CallbackDeps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil)), Telegram: tg})
+	poller := &UpdatesPoller{Client: tg, Handler: handler, Logger: slog.New(slog.NewTextHandler(io.Discard, nil)), PollTimeout: 50 * time.Millisecond}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { poller.Run(ctx); close(done) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("poller did not exit within 3s of cancel")
+	}
+}

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -16,8 +16,18 @@ import (
 )
 
 type Client interface {
-	SendMessage(ctx context.Context, chatID int64, threadID *int, text string) error
+	// SendMessage sends text to chatID; on success returns the Telegram message_id
+	// (0 when DryRun is on, since no network call is made).
+	SendMessage(ctx context.Context, chatID int64, threadID *int, text string, opts *SendOptions) (int64, error)
 	GetMe(ctx context.Context) error
+	GetUpdates(ctx context.Context, offset int64, timeout time.Duration) ([]Update, error)
+	AnswerCallbackQuery(ctx context.Context, callbackID, text string, showAlert bool) error
+	EditMessageText(ctx context.Context, chatID int64, messageID int64, text string, markup *InlineKeyboardMarkup) error
+	EditMessageReplyMarkup(ctx context.Context, chatID int64, messageID int64, markup *InlineKeyboardMarkup) error
+}
+
+type SendOptions struct {
+	ReplyMarkup *InlineKeyboardMarkup
 }
 
 type Config struct {
@@ -63,11 +73,12 @@ func New(cfg Config, limiter *Limiter, logger *slog.Logger) Client {
 }
 
 type sendMessagePayload struct {
-	ChatID                int64  `json:"chat_id"`
-	Text                  string `json:"text"`
-	ParseMode             string `json:"parse_mode,omitempty"`
-	DisableWebPagePreview bool   `json:"disable_web_page_preview"`
-	MessageThreadID       *int   `json:"message_thread_id,omitempty"`
+	ChatID                int64                 `json:"chat_id"`
+	Text                  string                `json:"text"`
+	ParseMode             string                `json:"parse_mode,omitempty"`
+	DisableWebPagePreview bool                  `json:"disable_web_page_preview"`
+	MessageThreadID       *int                  `json:"message_thread_id,omitempty"`
+	ReplyMarkup           *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
 type apiResponse struct {
@@ -82,20 +93,20 @@ type responseParams struct {
 	RetryAfter int `json:"retry_after"`
 }
 
-func (c *client) SendMessage(ctx context.Context, chatID int64, threadID *int, text string) error {
+func (c *client) SendMessage(ctx context.Context, chatID int64, threadID *int, text string, opts *SendOptions) (int64, error) {
 	if c.cfg.DryRun {
 		c.log.Info("dry run: skip telegram send",
 			"chat_id", chatID,
 			"thread_id", threadIDValue(threadID),
 			"text_len", len(text),
 		)
-		return nil
+		return 0, nil
 	}
 
 	if c.limiter != nil {
 		waited, err := c.limiter.Wait(ctx, chatID)
 		if err != nil {
-			return fmt.Errorf("rate limiter wait: %w", err)
+			return 0, fmt.Errorf("rate limiter wait: %w", err)
 		}
 		if waited > 50*time.Millisecond {
 			metrics.TelegramRateLimited.WithLabelValues(metrics.ChatLabel(chatID)).Inc()
@@ -109,19 +120,42 @@ func (c *client) SendMessage(ctx context.Context, chatID int64, threadID *int, t
 		DisableWebPagePreview: true,
 		MessageThreadID:       threadID,
 	}
+	if opts != nil {
+		payload.ReplyMarkup = opts.ReplyMarkup
+	}
 
 	endpoint := c.endpoint("sendMessage")
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("marshal sendMessage payload: %w", err)
+		return 0, fmt.Errorf("marshal sendMessage payload: %w", err)
 	}
 
-	return c.callWithRetry(ctx, endpoint, body)
+	okBody, err := c.callWithRetry(ctx, endpoint, body)
+	if err != nil {
+		return 0, err
+	}
+	return parseMessageID(okBody), nil
 }
 
 func (c *client) GetMe(ctx context.Context) error {
 	endpoint := c.endpoint("getMe")
-	return c.callWithRetry(ctx, endpoint, nil)
+	_, err := c.callWithRetry(ctx, endpoint, nil)
+	return err
+}
+
+func parseMessageID(body []byte) int64 {
+	if len(body) == 0 {
+		return 0
+	}
+	var ar struct {
+		Result struct {
+			MessageID int64 `json:"message_id"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &ar); err != nil {
+		return 0
+	}
+	return ar.Result.MessageID
 }
 
 func (c *client) endpoint(method string) string {
@@ -129,18 +163,18 @@ func (c *client) endpoint(method string) string {
 	return base
 }
 
-func (c *client) callWithRetry(ctx context.Context, endpoint string, body []byte) error {
+func (c *client) callWithRetry(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
 	var lastErr error
 	for attempt := 0; attempt < c.cfg.MaxAttempts; attempt++ {
-		err := c.callOnce(ctx, endpoint, body)
+		okBody, err := c.callOnce(ctx, endpoint, body)
 		if err == nil {
-			return nil
+			return okBody, nil
 		}
 		lastErr = err
 
 		retryable, reason := IsRetryable(err)
 		if !retryable {
-			return err
+			return nil, err
 		}
 		if attempt == c.cfg.MaxAttempts-1 {
 			break
@@ -169,14 +203,14 @@ func (c *client) callWithRetry(ctx context.Context, endpoint string, body []byte
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(wait):
 		}
 	}
-	return lastErr
+	return nil, lastErr
 }
 
-func (c *client) callOnce(ctx context.Context, endpoint string, body []byte) error {
+func (c *client) callOnce(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
 	var req *http.Request
 	var err error
 	if body == nil {
@@ -186,14 +220,14 @@ func (c *client) callOnce(ctx context.Context, endpoint string, body []byte) err
 		req.Header.Set("Content-Type", "application/json")
 	}
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return nil, fmt.Errorf("build request: %w", err)
 	}
 
 	start := time.Now()
 	resp, err := c.http.Do(req)
 	metrics.TelegramAPIDuration.Observe(time.Since(start).Seconds())
 	if err != nil {
-		return fmt.Errorf("http call: %w", err)
+		return nil, fmt.Errorf("http call: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -202,9 +236,9 @@ func (c *client) callOnce(ctx context.Context, endpoint string, body []byte) err
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		var ar apiResponse
 		if err := json.Unmarshal(respBody, &ar); err == nil && !ar.OK {
-			return &APIError{StatusCode: resp.StatusCode, Body: ar.Description}
+			return nil, &APIError{StatusCode: resp.StatusCode, Body: ar.Description}
 		}
-		return nil
+		return respBody, nil
 	}
 
 	ae := &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
@@ -224,7 +258,7 @@ func (c *client) callOnce(ctx context.Context, endpoint string, body []byte) err
 			}
 		}
 	}
-	return ae
+	return nil, ae
 }
 
 func asAPIError(err error) *APIError {

--- a/internal/telegram/client_test.go
+++ b/internal/telegram/client_test.go
@@ -49,7 +49,7 @@ func TestSendMessageOK(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(t, srv)
-	if err := c.SendMessage(context.Background(), 123, nil, "hi"); err != nil {
+	if _, err := c.SendMessage(context.Background(), 123, nil, "hi", nil); err != nil {
 		t.Fatal(err)
 	}
 	if got.ChatID != 123 || got.Text != "hi" || got.ParseMode != "HTML" || !got.DisableWebPagePreview {
@@ -67,7 +67,7 @@ func TestSendMessageThread(t *testing.T) {
 
 	thread := 42
 	c := newClient(t, srv)
-	if err := c.SendMessage(context.Background(), -100, &thread, "hi"); err != nil {
+	if _, err := c.SendMessage(context.Background(), -100, &thread, "hi", nil); err != nil {
 		t.Fatal(err)
 	}
 	if got.MessageThreadID == nil || *got.MessageThreadID != 42 {
@@ -91,7 +91,7 @@ func TestRetryOn429WithRetryAfter(t *testing.T) {
 	c := newClient(t, srv, func(c *Config) {
 		c.MaxBackoff = 20 * time.Millisecond
 	})
-	if err := c.SendMessage(context.Background(), 1, nil, "x"); err != nil {
+	if _, err := c.SendMessage(context.Background(), 1, nil, "x", nil); err != nil {
 		t.Fatal(err)
 	}
 	if attempts.Load() != 3 {
@@ -113,7 +113,7 @@ func TestRetryOn5xx(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(t, srv)
-	if err := c.SendMessage(context.Background(), 1, nil, "x"); err != nil {
+	if _, err := c.SendMessage(context.Background(), 1, nil, "x", nil); err != nil {
 		t.Fatal(err)
 	}
 	if attempts.Load() != 2 {
@@ -131,7 +131,7 @@ func TestNoRetryOn400(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(t, srv)
-	err := c.SendMessage(context.Background(), 1, nil, "x")
+	_, err := c.SendMessage(context.Background(), 1, nil, "x", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -154,7 +154,7 @@ func TestRetryRespectsContext(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	err := c.SendMessage(ctx, 1, nil, "x")
+	_, err := c.SendMessage(ctx, 1, nil, "x", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -183,7 +183,7 @@ func TestDryRunSkipsCall(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(t, srv, func(c *Config) { c.DryRun = true })
-	if err := c.SendMessage(context.Background(), 1, nil, "x"); err != nil {
+	if _, err := c.SendMessage(context.Background(), 1, nil, "x", nil); err != nil {
 		t.Fatal(err)
 	}
 	if called {

--- a/internal/telegram/updates.go
+++ b/internal/telegram/updates.go
@@ -1,0 +1,186 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type InlineKeyboardButton struct {
+	Text         string `json:"text"`
+	URL          string `json:"url,omitempty"`
+	CallbackData string `json:"callback_data,omitempty"`
+}
+
+type InlineKeyboardMarkup struct {
+	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard"`
+}
+
+type User struct {
+	ID        int64  `json:"id"`
+	Username  string `json:"username,omitempty"`
+	FirstName string `json:"first_name,omitempty"`
+}
+
+type Chat struct {
+	ID int64 `json:"id"`
+}
+
+type Message struct {
+	MessageID int64 `json:"message_id"`
+	Chat      Chat  `json:"chat"`
+}
+
+type CallbackQuery struct {
+	ID      string   `json:"id"`
+	From    User     `json:"from"`
+	Message *Message `json:"message,omitempty"`
+	Data    string   `json:"data,omitempty"`
+}
+
+type Update struct {
+	UpdateID      int64          `json:"update_id"`
+	CallbackQuery *CallbackQuery `json:"callback_query,omitempty"`
+}
+
+type getUpdatesRequest struct {
+	Offset         int64    `json:"offset,omitempty"`
+	Timeout        int      `json:"timeout,omitempty"`
+	AllowedUpdates []string `json:"allowed_updates,omitempty"`
+}
+
+type answerCallbackQueryRequest struct {
+	CallbackQueryID string `json:"callback_query_id"`
+	Text            string `json:"text,omitempty"`
+	ShowAlert       bool   `json:"show_alert,omitempty"`
+}
+
+type editMessageTextRequest struct {
+	ChatID                int64                 `json:"chat_id"`
+	MessageID             int64                 `json:"message_id"`
+	Text                  string                `json:"text"`
+	ParseMode             string                `json:"parse_mode,omitempty"`
+	DisableWebPagePreview bool                  `json:"disable_web_page_preview"`
+	ReplyMarkup           *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+type editMessageReplyMarkupRequest struct {
+	ChatID      int64                 `json:"chat_id"`
+	MessageID   int64                 `json:"message_id"`
+	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+func (c *client) GetUpdates(ctx context.Context, offset int64, timeout time.Duration) ([]Update, error) {
+	req := getUpdatesRequest{
+		Offset:         offset,
+		Timeout:        int(timeout.Seconds()),
+		AllowedUpdates: []string{"callback_query"},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal getUpdates: %w", err)
+	}
+
+	endpoint := c.endpoint("getUpdates")
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Use a dedicated HTTP client so long-poll timeout does not clash with RequestTimeout.
+	pollClient := &http.Client{Timeout: timeout + c.cfg.RequestTimeout}
+	resp, err := pollClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("getUpdates: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		ae := &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
+		var ar apiResponse
+		if err := json.Unmarshal(respBody, &ar); err == nil {
+			if ar.Description != "" {
+				ae.Body = ar.Description
+			}
+			if ar.Parameters != nil && ar.Parameters.RetryAfter > 0 {
+				ae.RetryAfter = time.Duration(ar.Parameters.RetryAfter) * time.Second
+			}
+		}
+		return nil, ae
+	}
+
+	var ar struct {
+		OK     bool     `json:"ok"`
+		Result []Update `json:"result"`
+	}
+	if err := json.Unmarshal(respBody, &ar); err != nil {
+		return nil, fmt.Errorf("decode getUpdates: %w", err)
+	}
+	if !ar.OK {
+		return nil, &APIError{StatusCode: resp.StatusCode, Body: "ok=false"}
+	}
+	return ar.Result, nil
+}
+
+func (c *client) AnswerCallbackQuery(ctx context.Context, callbackID, text string, showAlert bool) error {
+	if c.cfg.DryRun {
+		c.log.Info("dry run: skip answerCallbackQuery", "id", callbackID, "text", text)
+		return nil
+	}
+	req := answerCallbackQueryRequest{
+		CallbackQueryID: callbackID,
+		Text:            text,
+		ShowAlert:       showAlert,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal answerCallbackQuery: %w", err)
+	}
+	_, err = c.callWithRetry(ctx, c.endpoint("answerCallbackQuery"), body)
+	return err
+}
+
+func (c *client) EditMessageText(ctx context.Context, chatID int64, messageID int64, text string, markup *InlineKeyboardMarkup) error {
+	if c.cfg.DryRun {
+		c.log.Info("dry run: skip editMessageText", "chat_id", chatID, "message_id", messageID)
+		return nil
+	}
+	req := editMessageTextRequest{
+		ChatID:                chatID,
+		MessageID:             messageID,
+		Text:                  text,
+		ParseMode:             c.cfg.ParseMode,
+		DisableWebPagePreview: true,
+		ReplyMarkup:           markup,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal editMessageText: %w", err)
+	}
+	_, err = c.callWithRetry(ctx, c.endpoint("editMessageText"), body)
+	return err
+}
+
+func (c *client) EditMessageReplyMarkup(ctx context.Context, chatID int64, messageID int64, markup *InlineKeyboardMarkup) error {
+	if c.cfg.DryRun {
+		c.log.Info("dry run: skip editMessageReplyMarkup", "chat_id", chatID, "message_id", messageID)
+		return nil
+	}
+	req := editMessageReplyMarkupRequest{
+		ChatID:      chatID,
+		MessageID:   messageID,
+		ReplyMarkup: markup,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal editMessageReplyMarkup: %w", err)
+	}
+	_, err = c.callWithRetry(ctx, c.endpoint("editMessageReplyMarkup"), body)
+	return err
+}


### PR DESCRIPTION
## Summary

Phase 2b from TODO: in-chat silence actions for Alertmanager alerts.

- Long-poll `getUpdates` (no inbound webhook) → callback handler → Alertmanager `POST /api/v2/silences`.
- Single row of inline buttons on **firing** alertmanager messages to **allowlisted chats** (`🔇 Silence 1h/4h/24h`; durations configurable).
- Button lifecycle: `updates.button_ttl` (2h..48h, default 8h). A sweeper strips expired keyboards; late/orphaned clicks get `⏰ Silence window expired.`
- Off by default (`updates.enabled: false`). Zero change for existing deployments.

## How it works

```
alert webhook ─▶ handler ─┬─▶ sendMessage (with silence keyboard)
                          └─▶ tracker.Register(chat, msg_id, expires_at)

user click ─▶ getUpdates ─▶ CallbackHandler
                            ├─ allowlist (chat + optional user)
                            ├─ tracker.Valid → reject if expired/unknown
                            ├─ AM.GetAlertLabels (fallback: label cache)
                            ├─ AM.CreateSilence (matchers = all labels)
                            ├─ EditMessageReplyMarkup(nil)
                            └─ AnswerCallbackQuery(🔇 Silenced 1h until …)

sweeper (1min) ─▶ tracker.Sweep → EditMessageReplyMarkup(nil) for expired
```

## Config (all new, with defaults)

```yaml
updates:
  enabled: false
  poll_timeout: 30s
  chat_allowlist: []          # required for silence actions
  user_allowlist: []          # optional; empty = any chat member
  silence_durations: ["1h", "4h", "24h"]
  label_cache_ttl: 48h
  label_cache_max: 10000
  button_ttl: 8h              # validated 2h..48h

alertmanager:
  url: ""                     # required when updates.enabled
  request_timeout: 10s
```

Env (optional): `ALERTMANAGER_AUTH_USERNAME` + `_PASSWORD` (basic) or `ALERTMANAGER_AUTH_TOKEN` (bearer).

## Metrics

- `alertly_callbacks_received_total{action,status}` — statuses: `ok | invalid | auth_failed | expired | am_error | not_found`
- `alertly_silences_created_total{status}`
- `alertly_updates_poll_errors_total{reason}`

## Security & reliability notes

- `chat_allowlist` empty ⇒ no chat can silence. `user_allowlist` narrows further.
- Tracker is in-memory. Post-restart "orphan" keyboards in older chats reject clicks (strict policy) rather than silencing by guessed labels.
- `callback_data` format `s|<fp16>|<dur>` is ≤22 bytes — well under Telegram's 64-byte limit.
- AM silence matchers include all alert labels (amtool default behaviour), giving single-instance precision.
- `answerCallbackQuery` gets its own 5s sub-timeout so a stuck AM does not leave the user with a spinning button.

## Helm chart

- Exposes `config.updates.*` and `config.alertmanager.*` verbatim into ConfigMap.
- `secret.values.alertmanager{Username,Password,Token}` are optional — rendered only when set. Existing releases with just telegram/webhook tokens are unchanged.

## Test plan

- [x] Unit: AM client (happy + 5xx + basic/bearer auth), label cache (TTL, eviction, nil-safety), ButtonTracker (Register/Valid/Consume/Sweep with fake clock), ButtonSweeper (edits expired, continues on error, shutdown), CallbackHandler (happy path, cache fallback, unlisted chat/user, invalid duration, alert-not-found, AM error, expired window, consume-on-success), AlertmanagerKeyboard (firing/resolved/unlisted/other-source/empty-fp), UpdatesPoller (end-to-end dispatch, ctx cancel)
- [x] `go vet` + `go test -race -count=1 ./...` green
- [x] `helm lint` + `helm template` with `updates.enabled=true` render ConfigMap + Secret correctly
- [x] Local smoke: 9 webhook scenarios (auth/firing/resolved/multi-chat+thread/malformed/invalid chats/unknown source) all return expected status codes and metrics
- [x] Real-mode smoke against fake Telegram server: poller + sweeper start, outgoing `sendMessage` payloads inspected:
  - firing + allowlisted → 1 row of 3 silence buttons with `callback_data = s|<fp>|1h` (etc)
  - resolved → no `reply_markup`
  - firing + non-allowlisted → no `reply_markup`
- [ ] **Manual**: run with a real bot token, verify buttons render in Telegram client and callback→silence roundtrip hits a real Alertmanager. (Not done here — requires live credentials.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)