### PR TITLE
chore(release): v0.1.0 (chart 0.1.0, appVersion 0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-24
+
+Phase 2b from the roadmap: in-chat silence actions for Alertmanager alerts. Off by default; existing deployments are unaffected until `updates.enabled=true` is set.
+
+### Added
+- Interactive inline **silence buttons** on firing Alertmanager messages (`🔇 Silence 1h/4h/24h`, durations configurable). Single row, no URL buttons — Runbook link remains in message body.
+- **Telegram long polling** worker (`getUpdates` with `allowed_updates=["callback_query"]`) — no inbound HTTPS endpoint or Ingress changes required.
+- **Alertmanager client** (`internal/alertmanager`): `GET /api/v2/alerts` (resolve labels by fingerprint), `POST /api/v2/silences` (exact-match matchers from all alert labels). Supports basic auth (`ALERTMANAGER_AUTH_USERNAME`/`_PASSWORD`) and bearer (`ALERTMANAGER_AUTH_TOKEN`).
+- **LabelCache** — TTL+FIFO fallback so callbacks work even when AM has already forgotten about a resolved alert.
+- **ButtonTracker + sweeper** — messages expire after `updates.button_ttl` (validated 2h..48h, default 8h); sweeper strips inline keyboards once per minute; late or orphaned clicks rejected with `⏰ Silence window expired.`
+- Config sections `updates.*` and `alertmanager.*` with safe defaults (full validation refuses bad durations, missing AM URL, out-of-range `button_ttl`).
+- Metrics:
+  - `alertly_callbacks_received_total{action,status}` (statuses: `ok | invalid | auth_failed | expired | am_error | not_found`)
+  - `alertly_silences_created_total{status}`
+  - `alertly_updates_poll_errors_total{reason}`
+
+### Changed
+- `telegram.Client.SendMessage` now returns `(message_id int64, err error)` — required so the tracker can key by `(chat_id, message_id)`. Callers updated; `DryRun` path returns `(0, nil)`.
+- Helm chart `version 0.0.2 → 0.1.0`, `appVersion "0.0.3" → "0.1.0"`.
+- Helm chart exposes `config.updates.*`, `config.alertmanager.*`, and optional `secret.values.alertmanager{Username,Password,Token}` (rendered only when set — no change for existing installs).
+
+### Security
+- Silence actions gated by `updates.chat_allowlist` (empty ⇒ disabled) plus optional `user_allowlist`. Chat membership alone is **not** enough if `user_allowlist` is set.
+- Tracker entries are in-memory; after a restart older messages' buttons reject clicks rather than silencing with guessed labels.
+
 ## [0.0.3] - 2026-04-21
 
 Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to keep chart `appVersion` aligned with the code state after the following doc/test/example work.
@@ -34,6 +59,7 @@ Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to kee
 - Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
 - New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.0.3...HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/MaksimRudakov/alertly/compare/v0.0.3...v0.1.0
 [0.0.3]: https://github.com/MaksimRudakov/alertly/compare/v0.0.1...v0.0.3
 [0.0.1]: https://github.com/MaksimRudakov/alertly/releases/tag/v0.0.1

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.0.2
-appVersion: "0.0.3"
+version: 0.1.0
+appVersion: "0.1.0"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 


### PR DESCRIPTION
## Summary

Release bump for Phase 2b (interactive silence buttons via Telegram long polling), merged in #12.

- `charts/alertly/Chart.yaml`: `version 0.0.2 → 0.1.0`, `appVersion "0.0.3" → "0.1.0"`
- `CHANGELOG.md`: cut `[Unreleased]` into `[0.1.0] - 2026-04-24`, added compare links
- `charts/alertly/README.md`: regenerated badge (helm-docs)

Bump is **minor** (not patch): new functionality, new config surface (`updates.*`, `alertmanager.*`), new metrics, new optional secret keys. Backwards-compatible — existing deployments see no behaviour change because `updates.enabled` defaults to `false`.

## Release workflow trigger

After merge, tagging `v0.1.0` on main fires `.github/workflows/release.yaml`:

- **goreleaser** — multi-platform binaries + GitHub Release with autogenerated changelog
- **docker** — multi-arch `ghcr.io/maksimrudakov/alertly:0.1.0` (+ `0.1`, `0`, `latest`), cosign keyless-signed, SBOM attestation
- **chart-release** — `alertly-0.1.0.tgz` to GitHub Pages (helm repo) and OCI (`oci://ghcr.io/maksimrudakov/charts/alertly:0.1.0`), cosign keyless-signed

## Test plan

- [x] CHANGELOG compare links point at existing refs (v0.0.3 exists)
- [x] helm-docs regenerated cleanly (no drift)
- [ ] CI green on this PR (lint, test, build, trivy-fs, docker-build, chart-lint)
- [ ] Post-merge: `git tag v0.1.0 && git push origin v0.1.0` → release workflow succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)