### PR TITLE
chore(release): v0.3.0 (chart 0.3.0, appVersion 0.3.0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
           args: --timeout=5m
@@ -29,13 +29,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
       - run: go test -race -count=1 -coverprofile=coverage.out ./...
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           files: coverage.out
           fail_ci_if_error: false
@@ -43,18 +43,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
       - run: CGO_ENABLED=0 go build -trimpath -o /tmp/alertly ./cmd/alertly
 
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-file: go.mod
+          go-package: ./...
+
   trivy-fs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: aquasecurity/trivy-action@0.35.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -65,9 +73,9 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: false
@@ -77,7 +85,7 @@ jobs:
             VERSION=ci
             COMMIT=${{ github.sha }}
             DATE=ci
-      - uses: aquasecurity/trivy-action@0.35.0
+      - uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: alertly:ci
           severity: HIGH,CRITICAL
@@ -87,8 +95,8 @@ jobs:
   chart-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: azure/setup-helm@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.16.0
       - name: helm lint
@@ -105,7 +113,7 @@ jobs:
             --set secret.values.webhookAuthToken=ci \
             --set ingress.enabled=true \
             --set reloader.enabled=true > /tmp/rendered-full.yaml
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - name: Install helm-docs
@@ -117,3 +125,42 @@ jobs:
             echo "::error::charts/alertly/README.md is stale. Run 'helm-docs --chart-search-root=charts' locally and commit."
             exit 1
           fi
+
+  chart-install:
+    runs-on: ubuntu-latest
+    needs: chart-lint
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Build image
+        run: |
+          docker build -t alertly:ci \
+            --build-arg VERSION=ci \
+            --build-arg COMMIT=${{ github.sha }} \
+            --build-arg DATE=ci .
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: alertly-ci
+      - name: Load image into kind
+        run: kind load docker-image alertly:ci --name alertly-ci
+      - name: helm install
+        run: |
+          helm install alertly ./charts/alertly \
+            --set image.repository=alertly \
+            --set image.tag=ci \
+            --set image.pullPolicy=IfNotPresent \
+            --set secret.values.telegramBotToken=dummy \
+            --set secret.values.webhookAuthToken=dummy0123456789dummy0123456789aa \
+            --set env.DRY_RUN=true \
+            --wait --timeout 120s
+      - name: rollout status
+        run: kubectl rollout status deployment/alertly --timeout=120s
+      - name: Probe /healthz and /readyz
+        run: |
+          kubectl run curl --image=curlimages/curl:8.10.1 --rm -i --restart=Never -- \
+            sh -c 'curl -sf http://alertly.default.svc:8080/healthz && curl -sf http://alertly.default.svc:8080/readyz'
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -o wide || true
+          kubectl describe deployment alertly || true
+          kubectl logs deployment/alertly --tail=100 || true

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 3 * * 1" # weekly, Monday 03:17 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          languages: go
+          build-mode: none
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          category: "/language:go"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -19,10 +19,13 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
       - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: go
-          build-mode: none
+          build-mode: autobuild
       - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:go"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,14 +14,14 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -32,16 +32,16 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/alertly
           tags: |
@@ -50,7 +50,7 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
       - id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -63,7 +63,7 @@ jobs:
             DATE=${{ github.event.head_commit.timestamp }}
           provenance: true
           sbom: true
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
       - name: Sign image with cosign (keyless)
         env:
           COSIGN_EXPERIMENTAL: "true"
@@ -79,7 +79,7 @@ jobs:
     outputs:
       has_charts: ${{ steps.check.outputs.has_charts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - id: check
         run: |
           if compgen -G "charts/*/Chart.yaml" > /dev/null; then
@@ -98,23 +98,23 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v3.16.0
-      - uses: sigstore/cosign-installer@v3
-      - uses: docker/login-action@v4
+      - uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: helm/chart-releaser-action@v1.7.0
+      - uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: charts
           skip_existing: true

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,35 @@
+name: Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "43 4 * * 1" # weekly, Monday 04:43 UTC
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (publish_results: true).
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-05
+
+Reliability, observability and supply-chain hardening pass. No config changes required; all new chart features are opt-in.
+
+### Added
+- **Continuous Telegram health probe**: readiness is now driven by a periodic `getMe` (every 60s after startup, 3 consecutive failures flip unready), so a Telegram outage is detected even with no webhook traffic. Network-level send errors now count toward the readiness failure window (429 still does not, deliberately).
+- **Alertmanager client retry**: `GET /api/v2/alerts` and `POST /api/v2/silences` retry network errors, 429 and 5xx (3 attempts, linear backoff) — a transient AM blip no longer fails a button press.
+- Metrics: `alertly_label_cache_lookups_total{result}` and on-scrape size gauges `alertly_dedup_cache_entries`, `alertly_button_tracker_entries`, `alertly_label_cache_entries`.
+- Helm chart: native `podDisruptionBudget.{enabled,minAvailable,maxUnavailable}` and `metrics.serviceMonitor.*` (interval, scrapeTimeout, labels, relabelings) — both off by default, previously only available via `extraManifests`.
+- CI: `govulncheck` job (+ `make vuln`), CodeQL workflow, OpenSSF Scorecard workflow, kind-based chart install test (builds the image, `helm install --wait`, probes `/healthz` + `/readyz`).
+
+### Changed
+- **Callback processing is time-bounded** (15s per `callback_query`): a stuck Alertmanager or Telegram call no longer stalls the updates poller for minutes; the user still receives an answer.
+- **Graceful shutdown waits for background workers** (poller, sweepers, health probe) up to `server.shutdown_timeout`, so an in-flight silence completes its ack/edit.
+- **Kubewatch fingerprint now includes the event message**: dedup only absorbs identical redeliveries instead of collapsing distinct events on the same object for the whole TTL.
+- Silence buttons whose `callback_data` would exceed Telegram's 64-byte limit are skipped at build time instead of failing the whole `sendMessage`.
+- `getUpdates` long polling reuses a dedicated keep-alive HTTP client instead of building one per poll.
+- Supply chain: all GitHub Actions pinned to commit SHAs; Docker base images pinned by digest; builder synced to Go 1.26 (was downloading the toolchain at build time).
+- Internal: `LabelCache` eviction is O(1) (`container/list`), duplicated error-unwrap helpers replaced with `errors.As`.
+
+### Fixed
+- README: comparison table claimed inline buttons were «planned» (shipped in 0.1.0), metrics table was missing the callbacks/silences/poll-errors metrics, prerequisites mentioned a non-existent `startupProbe`.
+
 ## [0.2.0] - 2026-05-06
 
 Reliability hardening for the Alertmanager-retry duplicate problem: when alertly successfully delivered a message to Telegram but did not ACK the webhook in time, Alertmanager would retry and the same alert was posted twice. Two complementary changes close that path. Defaults are safe — existing deployments get the fix on upgrade with no config changes required.
@@ -79,7 +102,8 @@ Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to kee
 - Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
 - New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/MaksimRudakov/alertly/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/MaksimRudakov/alertly/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/MaksimRudakov/alertly/compare/v0.0.3...v0.1.0
 [0.0.3]: https://github.com/MaksimRudakov/alertly/compare/v0.0.1...v0.0.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Go: `1.25` (toolchain `go1.26.2`)
 - Single binary entry: `cmd/alertly`
 
-README references a `SPEC.md` that does not exist in the tree — treat README + `examples/config.yaml` + `TODO.md` as the source of truth for current scope. `TODO.md` lists Phase 2 items (dedup, inline buttons, generic source, label routing, async queue, Markdown, two-way chat) that are intentionally out of MVP.
+Treat README + `examples/config.yaml` + `TODO.md` as the source of truth for current scope. Dedup and interactive silence buttons (Phase 2b) are shipped; `TODO.md` lists the remaining Phase 2/3 items (generic source, label routing, async queue, Markdown, chat-ops commands) that are intentionally deferred until a real signal demands them.
 
 ## Common commands
 
@@ -57,7 +57,7 @@ Lint config (`.golangci.yaml`) is intentionally minimal: `gofmt`, `goimports`, `
 
 `alertmanager`: standard webhook payload; severity from `labels.severity` (default `info`); title prefers `annotations.summary`, body prefers `annotations.description`; emits a Runbook link from `annotations.runbook_url` when present (Prometheus `generatorURL` is intentionally ignored — internal Prometheus links are rarely reachable from Telegram and add noise).
 
-`kubewatch`: tries new (`eventmeta`) format then legacy flat; severity becomes `warning` for `Type=Warning` or `Reason=Failed`; fingerprint is sha256-16 of `kind|namespace|name|reason|type`.
+`kubewatch`: tries new (`eventmeta`) format then legacy flat; severity becomes `warning` for `Type=Warning` or `Reason=Failed`; fingerprint is sha256-16 of `kind|namespace|name|reason|type|message` — the message is included deliberately so dedup only absorbs identical redeliveries, not distinct events on the same object.
 
 ### Notification → Telegram
 
@@ -73,15 +73,28 @@ Retry is **deadline-aware**: before sleeping for the next backoff, the client ch
 
 In-process TTL cache keyed by `fingerprint|chat_id|thread_id|status`. `Reserve(key)` is the atomic check-and-insert; `Forget(key)` rolls back when no part of a multi-part message landed. Per-process state — restart re-opens the dedup window. The handler reserves once per `(notification, target)` after rendering and only forgets when *every* part for that target failed (partial successes keep the reservation so caller retries don't re-deliver the parts already in the chat). Default `enabled: true, ttl: 1h`. Metric: `alertly_dedup_skipped_total{source,chat_id,status}`. Sweeper goroutine in `cmd/alertly/main.go` runs every `min(ttl/2, 5m)`.
 
+### Interactive silence buttons (`updates.*`)
+
+Off by default; enabled via `updates.enabled` + `alertmanager.url`. Moving parts (all wired in `setupUpdates` in `main.go`):
+- `server.AlertmanagerKeyboard` (keyboard.go) attaches a `🔇 Silence <dur>` row to firing alertmanager notifications in allowlisted chats; buttons whose `callback_data` would exceed Telegram's 64-byte limit are skipped (a keyboard with no valid buttons is dropped).
+- `server.UpdatesPoller` (updates.go) long-polls `getUpdates` (`allowed_updates=["callback_query"]`) through a dedicated keep-alive HTTP client; each callback is handled synchronously under a 15s `HandleTimeout` so a stuck AM/Telegram call cannot stall the loop. Offset is in-memory → delivery is at-least-once.
+- `server.CallbackHandler` (callback.go) validates chat/user allowlists and the `ButtonTracker` window, resolves labels (AM API → `alertmanager.LabelCache` fallback, hit/miss metered), creates the silence, strips the keyboard. `answer()` runs on a context detached from the handle budget so the user always gets feedback.
+- `server.ButtonTracker` + sweeper (button_tracker.go): in-memory TTL registry of messages with live buttons; restart invalidates old buttons (strict policy).
+- `internal/alertmanager.client` retries network errors, 429 and 5xx up to 3 attempts with linear backoff (300ms step); 4xx is terminal. A duplicate silence from a retried POST is harmless (identical matchers).
+- `alertmanager.LabelCache` is a TTL+FIFO map with O(1) eviction (`container/list`).
+
 ### Readiness model
 
 `server/readyz.go` `ReadinessTracker`:
 - starts unready with reason `startup: telegram getMe pending`;
-- `startupCheck` in `main.go` calls `tg.GetMe` with exponential backoff and flips to ready on success;
-- runtime: `RecordSendSuccess` resets a failure counter and re-arms ready; `RecordSendFailure(serverError=true)` increments and flips to unready after `readyzFailureWindow=10` consecutive 5xx;
-- 4xx send failures do NOT degrade readiness (they're treated as caller/data problems).
+- `telegramHealthLoop` in `main.go` probes `tg.GetMe` continuously: exponential backoff until the first success (flips ready), then every minute; 3 consecutive probe failures flip unready. Probe success only re-arms probe-driven unreadiness — it never overrides the send-failure window below;
+- runtime: `RecordSendSuccess` resets a failure counter and re-arms ready; `RecordSendFailure(serverError=true)` increments and flips to unready after `readyzFailureWindow=10` consecutive failures. Server errors = Telegram 5xx **and** network-level errors; 4xx and 429 do NOT degrade readiness (caller/data problems and backpressure respectively).
 
 `/healthz` is unconditional 200; `/readyz` returns 503 with JSON reason when not ready.
+
+### Shutdown
+
+`run()` tracks every background worker (health loop, updates poller, button sweeper, dedup sweeper) in a `sync.WaitGroup`; after `srv.Run` returns it cancels the root context and waits up to `server.shutdown_timeout` for them to finish, so an in-flight silence callback completes its ack/edit instead of being cut off.
 
 ### Configuration
 
@@ -91,7 +104,7 @@ Required env: `TELEGRAM_BOT_TOKEN`, `WEBHOOK_AUTH_TOKEN`. Optional: `ALERTLY_CON
 
 ### Metrics
 
-All in `internal/metrics`. Custom registry (no default Go process collectors except those explicitly registered: `NewGoCollector`, `NewProcessCollector`). `Init()` is idempotent via `sync.Once`. Names: `alertly_notifications_{received,sent}_total`, `alertly_telegram_{api_duration_seconds,retries_total,rate_limited_total}` (the `retries_total` reason `deadline_skip` marks aborted retries), `alertly_template_render_errors_total`, `alertly_message_split_total`, `alertly_auth_failures_total`, `alertly_source_parse_duration_seconds`, `alertly_dedup_skipped_total`, `alertly_build_info`.
+All in `internal/metrics`. Custom registry (no default Go process collectors except those explicitly registered: `NewGoCollector`, `NewProcessCollector`). `Init()` is idempotent via `sync.Once`. Names: `alertly_notifications_{received,sent}_total`, `alertly_telegram_{api_duration_seconds,retries_total,rate_limited_total}` (the `retries_total` reason `deadline_skip` marks aborted retries), `alertly_template_render_errors_total`, `alertly_message_split_total`, `alertly_auth_failures_total`, `alertly_source_parse_duration_seconds`, `alertly_dedup_skipped_total`, `alertly_callbacks_received_total`, `alertly_silences_created_total`, `alertly_updates_poll_errors_total`, `alertly_label_cache_lookups_total`, `alertly_build_info`. Cache sizes are exposed as on-scrape gauges (`alertly_{dedup_cache,button_tracker,label_cache}_entries`) registered from `main.go` via `metrics.RegisterSizeGauge`.
 
 ## Repo conventions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG GO_VERSION=1.25
-FROM golang:${GO_VERSION}-alpine AS builder
+ARG GO_VERSION=1.26
+FROM golang:${GO_VERSION}-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 ARG VERSION=dev
 ARG COMMIT=none
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
         -X github.com/MaksimRudakov/alertly/internal/version.Date=${DATE}" \
       -o /alertly ./cmd/alertly
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
 
 USER 65532:65532
 COPY --from=builder /alertly /alertly

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GO          ?= go
 GOFLAGS     ?=
 DOCKER_TAG  ?= alertly:dev
 
-.PHONY: all build test test-cover lint fmt run docker clean tidy
+.PHONY: all build test test-cover lint fmt run docker clean tidy vuln
 
 all: lint test build
 
@@ -36,6 +36,14 @@ lint:
 	  echo "golangci-lint not installed; running go vet + staticcheck fallback"; \
 	  $(GO) vet ./...; \
 	  command -v staticcheck >/dev/null && staticcheck ./... || true; \
+	fi
+
+vuln:
+	@if command -v govulncheck >/dev/null; then \
+	  govulncheck ./...; \
+	else \
+	  echo "govulncheck not installed; running via 'go run'"; \
+	  $(GO) run golang.org/x/vuln/cmd/govulncheck@latest ./...; \
 	fi
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Lightweight HTTP service that ingests webhooks from **Alertmanager** and **Kubew
 ## Features
 
 - Sources: Alertmanager (v4 webhook) and Kubewatch (new + legacy payload).
+- **Interactive Silence buttons** on firing Alertmanager alerts: inline keyboard via Telegram long polling, silences created through the Alertmanager API v2, chat/user allowlists, TTL-limited button window. Off by default (`updates.enabled`).
 - Multiple chats and topic threads per webhook URL: `/v1/alertmanager/-100123,-100456:42`.
 - Per-chat + global Telegram rate limiter; retry with exponential backoff and `Retry-After` honoring.
 - **Deadline-aware retry**: aborts the next backoff sleep when there's no time left to ACK the caller, preventing «delivered to Telegram but caller already gave up» duplicates.
@@ -36,7 +37,7 @@ docker run --rm -p 8080:8080 \
 
 ### Prerequisites
 
-- Kubernetes 1.25+ (probes use `startupProbe`-compatible semantics).
+- Kubernetes 1.25+.
 - Helm 3.8+ (required for OCI install; any 3.x works for the HTTP repo).
 - A Telegram bot token from [@BotFather](https://t.me/BotFather) and any random string for `WEBHOOK_AUTH_TOKEN` (at least 32 chars recommended).
 - The bot added to the target chat(s); get the chat ID from [@RawDataBot](https://t.me/RawDataBot) or your own method.
@@ -54,7 +55,7 @@ helm search repo alertly
 OCI (GitHub Container Registry, no `helm repo add` needed):
 
 ```bash
-helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.2.0
+helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.3.0
 ```
 
 ### Install
@@ -64,7 +65,7 @@ Quick install with tokens passed directly (fine for a lab / personal cluster —
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.2.0 \
+  --version 0.3.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -74,7 +75,7 @@ Or from OCI:
 ```bash
 helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.2.0 \
+  --version 0.3.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -100,7 +101,7 @@ Then install referencing it:
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.2.0 \
+  --version 0.3.0 \
   --set secret.create=false \
   --set secret.existingSecret=alertly-tokens \
   --set reloader.enabled=true   # optional: auto-restart on Secret/ConfigMap changes
@@ -117,15 +118,15 @@ Both the chart tarball (attached to the GitHub Release) and the OCI chart manife
 cosign verify \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/maksimrudakov/charts/alertly:0.2.0
+  ghcr.io/maksimrudakov/charts/alertly:0.3.0
 
-# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.2.0 release)
+# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.3.0 release)
 cosign verify-blob \
-  --certificate alertly-0.2.0.tgz.pem \
-  --signature alertly-0.2.0.tgz.sig \
+  --certificate alertly-0.3.0.tgz.pem \
+  --signature alertly-0.3.0.tgz.sig \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  alertly-0.2.0.tgz
+  alertly-0.3.0.tgz
 ```
 
 The container image `ghcr.io/maksimrudakov/alertly` is signed the same way.
@@ -156,7 +157,7 @@ Full list of values with defaults and descriptions: [`charts/alertly/README.md`]
 | `POST` | `/v1/alertmanager/{chats}` | Bearer | Alertmanager webhook |
 | `POST` | `/v1/kubewatch/{chats}` | Bearer | Kubewatch webhook |
 | `GET`  | `/healthz` | — | Liveness |
-| `GET`  | `/readyz`  | — | Readiness (`getMe` ok + recent send health) |
+| `GET`  | `/readyz`  | — | Readiness (periodic `getMe` probe + recent send health) |
 | `GET`  | `/metrics` | — | Prometheus metrics |
 
 `{chats}` accepts a comma-separated list of chat IDs with an optional thread:
@@ -173,6 +174,8 @@ Path from `ALERTLY_CONFIG` (default `/etc/alertly/config.yaml`). See [examples/c
 | `ALERTLY_CONFIG` | no  | Path to config (default `/etc/alertly/config.yaml`) |
 | `LOG_LEVEL` | no  | Override `logging.level` from config |
 | `DRY_RUN`   | no  | When `true`, skip Telegram calls but log/meter |
+| `ALERTMANAGER_AUTH_USERNAME` / `ALERTMANAGER_AUTH_PASSWORD` | no | Basic auth for the Alertmanager API (silence buttons) |
+| `ALERTMANAGER_AUTH_TOKEN` | no | Bearer auth for the Alertmanager API (takes precedence over basic) |
 
 Hot reload of config is intentionally **not** supported in-process — use [`stakater/Reloader`](https://github.com/stakater/Reloader) to roll the Deployment on ConfigMap/Secret change.
 
@@ -180,11 +183,35 @@ Hot reload of config is intentionally **not** supported in-process — use [`sta
 
 Stored inline in YAML, parsed via `text/template`. Helper funcs: `severity_emoji`, `escape_html`, `truncate`, `join`, `humanize_duration`. A template named per source (`alertmanager`, `kubewatch`) is preferred; falls back to `default`.
 
+> **Escaping**: templates are `text/template`, not `html/template` — there is no auto-escaping. With `parse_mode: HTML`, always pipe user-controlled fields (`.Title`, `.Body`, `.Labels`, `.Annotations`) through `escape_html`, otherwise a label containing `<` or `&` makes Telegram reject the whole message with 400.
+
+## Interactive silence buttons
+
+Firing Alertmanager alerts can carry a row of `🔇 Silence 1h/4h/24h` inline buttons. Pressing one creates a silence via `POST /api/v2/silences` with exact-match matchers built from all alert labels. Delivery of button presses uses Telegram **long polling** (`getUpdates`) — no inbound endpoint or Ingress changes.
+
+```yaml
+updates:
+  enabled: true
+  chat_allowlist: [-1001234567890]   # required: only these chats can silence
+  user_allowlist: []                 # optional: restrict to specific user IDs
+  silence_durations: ["1h", "4h", "24h"]
+  button_ttl: 8h                     # buttons expire and are stripped after this
+alertmanager:
+  url: http://alertmanager.monitoring.svc:9093
+```
+
+Operational notes:
+
+- Buttons expire after `button_ttl`; a background sweeper strips expired keyboards, late clicks are rejected.
+- Button state is in-memory: after a pod restart old buttons are rejected with «Silence window expired» (strict policy — no accidental silences from stale state).
+- Callback processing is bounded (15s per press) and transient Alertmanager errors are retried; delivery of callbacks is at-least-once, so in a narrow crash window a silence can be created twice — duplicates are harmless (identical matchers).
+- Labels are resolved via the AM API with an in-process fallback cache, so resolving works even when AM has already dropped the alert.
+
 ## Deduplication
 
 Telegram has no idempotency key, so any retry from upstream — most commonly Alertmanager re-sending a webhook because the previous response did not arrive in time — would be delivered as a fresh chat message. alertly absorbs that retry with a small in-process cache.
 
-Key: `fingerprint | chat_id | thread_id | status` (so `firing` and `resolved` of the same alert are kept separate).
+Key: `fingerprint | chat_id | thread_id | status` (so `firing` and `resolved` of the same alert are kept separate). For Kubewatch the fingerprint includes the event message, so two different events on the same object (e.g. `CrashLoopBackOff` with changing restart counts) are **not** collapsed — only identical redeliveries are.
 
 | Setting | Default | Notes |
 |---|---|---|
@@ -203,7 +230,7 @@ The cache is **per-process**. With multiple alertly replicas behind a `Service`,
 
 | Setup | When | Note |
 |---|---|---|
-| `replicaCount: 1` + PDB `maxUnavailable: 0` | **default recommendation** | alertly is stateless and lightweight; restart window is the only dedup blind-spot. |
+| `replicaCount: 1` + PDB `maxUnavailable: 0` | **default recommendation** | alertly is stateless and lightweight; restart window is the only dedup blind-spot. Enable via `podDisruptionBudget.enabled=true` in the chart (note: with 1 replica it blocks voluntary node drains until the pod is moved manually). |
 | `replicaCount: N` + Ingress with consistent-hash on path | when an HA policy mandates >1 replica | e.g. nginx `nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"` — same `/v1/.../{chats}` URL always goes to the same pod. |
 | Shared cache (Redis / Valkey) | not implemented | Would only be worth it if the HA Alertmanager pair itself fans out the same webhook from both replicas. Kept out of scope until a real signal demands it. |
 
@@ -220,7 +247,7 @@ A pod restart re-opens the dedup window for all in-flight alerts — accepted tr
 | Multiple chats per webhook URL | yes | yes | n/a | per-receiver |
 | Topic threads | yes | no | n/a | yes |
 | Message splitting >4096 | yes | no (truncates) | n/a | no (errors) |
-| Inline buttons (Phase 2) | planned | no | yes | no |
+| Inline silence buttons | yes | no | yes | no |
 | Per-chat rate limit | yes | no | n/a | no |
 | Prometheus metrics | yes | no | yes | yes |
 
@@ -238,9 +265,16 @@ A pod restart re-opens the dedup window for all in-flight alerts — accepted tr
 | `alertly_auth_failures_total` | counter | — |
 | `alertly_source_parse_duration_seconds` | histogram | `source` |
 | `alertly_dedup_skipped_total` | counter | `source`, `chat_id`, `status` |
+| `alertly_callbacks_received_total` | counter | `action`, `status` |
+| `alertly_silences_created_total` | counter | `status` |
+| `alertly_updates_poll_errors_total` | counter | `reason` |
+| `alertly_label_cache_lookups_total` | counter | `result` (`hit`/`miss`) |
+| `alertly_dedup_cache_entries` | gauge | — |
+| `alertly_button_tracker_entries` | gauge | — |
+| `alertly_label_cache_entries` | gauge | — |
 | `alertly_build_info` | gauge | `version`, `commit`, `go_version` |
 
-`alertly_telegram_retries_total` uses these `reason` values: `429`, `5xx`, `network`, and `deadline_skip` (retry aborted because the request context would expire before the next backoff completed).
+`alertly_telegram_retries_total` uses these `reason` values: `429`, `5xx`, `network`, and `deadline_skip` (retry aborted because the request context would expire before the next backoff completed). The `*_entries` gauges expose in-process cache sizes so unexpected growth is visible.
 
 ## Troubleshooting
 
@@ -253,6 +287,9 @@ A pod restart re-opens the dedup window for all in-flight alerts — accepted tr
 | Long messages dropped silently | not split? always check `alertly_message_split_total` | verify `parse_mode` is `HTML` and template doesn't emit unbalanced tags |
 | Same alert delivered to Telegram twice | multiple alertly replicas without sticky routing | run `replicaCount: 1`, or hash the request path to a pod (see [Deduplication › Scaling](#scaling-considerations)) |
 | `alertly_telegram_retries_total{reason="deadline_skip"}` growing | server `WriteTimeout` shorter than worst-case retry budget | raise `server.write_timeout` or lower `telegram.retry.max_backoff`; check Telegram `Retry-After` headers in logs |
+| Silence buttons not shown on alerts | `updates.enabled: false`, chat not in `chat_allowlist`, or alert not `firing` | enable updates, add the chat ID to `updates.chat_allowlist`; buttons are only attached to firing Alertmanager alerts |
+| Button press answers «Silence window expired» | button older than `updates.button_ttl` or alertly restarted since the message was sent | expected (strict policy); re-fire the alert or silence via AM UI |
+| Button press answers «Failed to query Alertmanager» | `alertmanager.url` wrong/unreachable or auth missing | check `alertmanager.url`, `ALERTMANAGER_AUTH_*` env, NetworkPolicy to AM; see `alertly_updates_poll_errors_total` and logs |
 
 ## Architecture
 

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 
@@ -31,7 +31,7 @@ Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 | config.updates.user_allowlist | list | `[]` | Optional user allowlist within allowlisted chats. Empty = any chat member. |
 | env | object | `{"LOG_LEVEL":"info"}` | Env vars passed to the container. Keys become env names, values are quoted as strings. |
 | extraEnv | list | `[]` | Extra env vars in full k8s EnvVar form (supports `valueFrom`). |
-| extraManifests | list | `[]` | Raw manifests rendered as-is. Use for PodMonitor/ServiceMonitor, PDB, NetworkPolicy, etc. without forking the chart.  Example — PodMonitor for kube-prometheus-stack: extraManifests:   - apiVersion: monitoring.coreos.com/v1     kind: PodMonitor     metadata:       name: alertly       labels:         release: kube-prometheus-stack     spec:       selector:         matchLabels:           app.kubernetes.io/name: alertly       podMetricsEndpoints:         - port: http           path: /metrics           interval: 30s  Example — PodDisruptionBudget: extraManifests:   - apiVersion: policy/v1     kind: PodDisruptionBudget     metadata:       name: alertly     spec:       maxUnavailable: 0       selector:         matchLabels:           app.kubernetes.io/name: alertly |
+| extraManifests | list | `[]` | Raw manifests rendered as-is. Use for resources the chart does not template natively (e.g. NetworkPolicy). For Prometheus scraping and disruption budgets prefer the native `metrics.serviceMonitor` and `podDisruptionBudget` blocks above. |
 | fullnameOverride | string | `""` | Override full release name. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | image.repository | string | `"ghcr.io/maksimrudakov/alertly"` | Container image repository. |
@@ -42,9 +42,19 @@ Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 | ingress.enabled | bool | `false` | Enable Ingress for the alertly webhook endpoint. |
 | ingress.hosts | list | `[{"host":"alertly.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]` | Ingress host/path rules. |
 | ingress.tls | list | `[]` | Ingress TLS blocks. |
+| metrics.serviceMonitor.additionalLabels | object | `{}` | Extra labels on the ServiceMonitor (e.g. `release: kube-prometheus-stack` to match the operator's serviceMonitorSelector). |
+| metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor for the Prometheus Operator. Requires the monitoring.coreos.com/v1 CRDs — rendering fails with a hint when the cluster does not expose them. |
+| metrics.serviceMonitor.honorLabels | bool | `false` | Keep target labels on collision with server-side labels. |
+| metrics.serviceMonitor.interval | string | `"30s"` | Scrape interval. |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` | Metric relabelings applied to samples before ingestion. |
+| metrics.serviceMonitor.relabelings | list | `[]` | Relabelings applied to targets before scraping. |
+| metrics.serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout. Empty = Prometheus default. |
 | nameOverride | string | `""` | Override chart name. |
 | nodeSelector | object | `{}` | Pod nodeSelector. |
 | podAnnotations | object | `{}` | Extra annotations for the pod. |
+| podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. Recommended setup for the default `replicaCount: 1`: `maxUnavailable: 0` protects the in-process dedup window (`config.dedup` is per-pod) from voluntary evictions — but with a single replica it also blocks node drain until manual intervention, hence disabled by default. Enable it when losing the dedup window on drain is worse for you than a stuck drain. |
+| podDisruptionBudget.maxUnavailable | int | `0` | Max pods that may be voluntarily evicted. Used when `minAvailable` is not set. |
+| podDisruptionBudget.minAvailable | string | `""` | Min pods that must stay available (int or percentage). Mutually exclusive with `maxUnavailable`; takes precedence when set. |
 | podLabels | object | `{}` | Extra labels for the pod. |
 | podSecurityContext | object | `{"fsGroup":65532,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level security context. |
 | priorityClassName | string | `""` | Pod priorityClassName. |

--- a/charts/alertly/templates/pdb.yaml
+++ b/charts/alertly/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "alertly.fullname" . }}
+  labels:
+    {{- include "alertly.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "alertly.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/alertly/templates/servicemonitor.yaml
+++ b/charts/alertly/templates/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.metrics.serviceMonitor.enabled -}}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+{{- fail "metrics.serviceMonitor.enabled=true, but the cluster does not expose monitoring.coreos.com/v1. Install the Prometheus Operator CRDs (e.g. kube-prometheus-stack) first, or pass `--api-versions monitoring.coreos.com/v1` when templating offline." -}}
+{{- end -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "alertly.fullname" . }}
+  labels:
+    {{- include "alertly.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "alertly.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/alertly/values.yaml
+++ b/charts/alertly/values.yaml
@@ -142,6 +142,40 @@ extraEnv: []
 # -- Grace period before SIGKILL.
 terminationGracePeriodSeconds: 30
 
+podDisruptionBudget:
+  # -- Create a PodDisruptionBudget. Recommended setup for the default
+  # `replicaCount: 1`: `maxUnavailable: 0` protects the in-process dedup window
+  # (`config.dedup` is per-pod) from voluntary evictions — but with a single
+  # replica it also blocks node drain until manual intervention, hence disabled
+  # by default. Enable it when losing the dedup window on drain is worse for
+  # you than a stuck drain.
+  enabled: false
+  # -- Max pods that may be voluntarily evicted. Used when `minAvailable` is not set.
+  maxUnavailable: 0
+  # -- Min pods that must stay available (int or percentage). Mutually exclusive
+  # with `maxUnavailable`; takes precedence when set.
+  minAvailable: ""
+
+metrics:
+  serviceMonitor:
+    # -- Create a ServiceMonitor for the Prometheus Operator. Requires the
+    # monitoring.coreos.com/v1 CRDs — rendering fails with a hint when the
+    # cluster does not expose them.
+    enabled: false
+    # -- Scrape interval.
+    interval: 30s
+    # -- Scrape timeout. Empty = Prometheus default.
+    scrapeTimeout: ""
+    # -- Extra labels on the ServiceMonitor (e.g. `release: kube-prometheus-stack`
+    # to match the operator's serviceMonitorSelector).
+    additionalLabels: {}
+    # -- Keep target labels on collision with server-side labels.
+    honorLabels: false
+    # -- Relabelings applied to targets before scraping.
+    relabelings: []
+    # -- Metric relabelings applied to samples before ingestion.
+    metricRelabelings: []
+
 # -- Pod nodeSelector.
 nodeSelector: {}
 # -- Pod tolerations.
@@ -238,34 +272,7 @@ config:
     enabled: true
     ttl: 1h
 
-# -- Raw manifests rendered as-is. Use for PodMonitor/ServiceMonitor, PDB, NetworkPolicy, etc. without forking the chart.
-#
-# Example — PodMonitor for kube-prometheus-stack:
-# extraManifests:
-#   - apiVersion: monitoring.coreos.com/v1
-#     kind: PodMonitor
-#     metadata:
-#       name: alertly
-#       labels:
-#         release: kube-prometheus-stack
-#     spec:
-#       selector:
-#         matchLabels:
-#           app.kubernetes.io/name: alertly
-#       podMetricsEndpoints:
-#         - port: http
-#           path: /metrics
-#           interval: 30s
-#
-# Example — PodDisruptionBudget:
-# extraManifests:
-#   - apiVersion: policy/v1
-#     kind: PodDisruptionBudget
-#     metadata:
-#       name: alertly
-#     spec:
-#       maxUnavailable: 0
-#       selector:
-#         matchLabels:
-#           app.kubernetes.io/name: alertly
+# -- Raw manifests rendered as-is. Use for resources the chart does not template
+# natively (e.g. NetworkPolicy). For Prometheus scraping and disruption budgets
+# prefer the native `metrics.serviceMonitor` and `podDisruptionBudget` blocks above.
 extraManifests: []

--- a/cmd/alertly/main.go
+++ b/cmd/alertly/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -120,22 +121,49 @@ func run() error {
 	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	var wg sync.WaitGroup
+	startWorker := func(w func(context.Context)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w(rootCtx)
+		}()
+	}
+
 	if dryRun {
 		readiness.MarkReady()
 		logger.Warn("DRY_RUN active: telegram calls are skipped")
 	} else {
-		go startupCheck(rootCtx, tgClient, readiness, logger)
+		startWorker(func(ctx context.Context) { telegramHealthLoop(ctx, tgClient, readiness, logger, time.Minute) })
 	}
 
 	for _, w := range bgWorkers {
-		go w(rootCtx)
+		startWorker(w)
 	}
 
 	if dedupCache != nil {
-		go dedupCache.Run(rootCtx, 0)
+		startWorker(func(ctx context.Context) { dedupCache.Run(ctx, 0) })
+		metrics.RegisterSizeGauge("alertly_dedup_cache_entries",
+			"Current number of entries in the dedup cache.", dedupCache.Len)
 	}
 
-	return srv.Run(rootCtx)
+	err = srv.Run(rootCtx)
+
+	// srv.Run returns after graceful HTTP shutdown (or a listen error). Cancel
+	// the workers explicitly for the error path and wait so a callback that is
+	// mid-CreateSilence can finish its ack/edit instead of being cut off.
+	stop()
+	workersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(workersDone)
+	}()
+	select {
+	case <-workersDone:
+	case <-time.After(cfg.Server.ShutdownTimeout):
+		logger.Warn("background workers did not stop within shutdown timeout")
+	}
+	return err
 }
 
 func setupUpdates(cfg config.Config, tgClient telegram.Client, logger *slog.Logger) (server.KeyboardBuilder, server.ButtonRegistrar, []func(context.Context), error) {
@@ -152,6 +180,10 @@ func setupUpdates(cfg config.Config, tgClient telegram.Client, logger *slog.Logg
 
 	cache := alertmanager.NewLabelCache(cfg.Updates.LabelCacheTTL, cfg.Updates.LabelCacheMax)
 	tracker := server.NewButtonTracker(cfg.Updates.ButtonTTL)
+	metrics.RegisterSizeGauge("alertly_label_cache_entries",
+		"Current number of fingerprints in the Alertmanager label cache.", cache.Len)
+	metrics.RegisterSizeGauge("alertly_button_tracker_entries",
+		"Current number of alert messages with active silence buttons.", tracker.Len)
 
 	durations := make(map[string]time.Duration, len(cfg.Updates.SilenceDurations))
 	for _, d := range cfg.Updates.SilenceDurations {
@@ -177,6 +209,7 @@ func setupUpdates(cfg config.Config, tgClient telegram.Client, logger *slog.Logg
 		Durations:     cfg.Updates.SilenceDurations,
 		ChatAllowlist: cfg.Updates.ChatAllowlist,
 		Cache:         cache,
+		Logger:        logger,
 	}
 
 	poller := &server.UpdatesPoller{
@@ -227,37 +260,67 @@ func requireEnv(name string) string {
 	return strings.TrimSpace(os.Getenv(name))
 }
 
-func startupCheck(ctx context.Context, c telegram.Client, r server.ReadinessTracker, logger *slog.Logger) {
+// telegramHealthLoop drives readiness from Telegram getMe. During startup any
+// failure keeps the pod unready (original startupCheck behaviour). Once ready,
+// it keeps probing every probeInterval so an outage is detected even when no
+// webhooks are flowing; a few consecutive failures are tolerated to avoid
+// flapping on transient errors. It never overrides a send-failure-driven
+// unready state with MarkReady: recovery from that path comes via
+// RecordSendSuccess, probe success only re-arms probe-driven unreadiness.
+func telegramHealthLoop(ctx context.Context, c telegram.Client, r server.ReadinessTracker, logger *slog.Logger, probeInterval time.Duration) {
+	const (
+		probeTimeout     = 10 * time.Second
+		maxBackoff       = 30 * time.Second
+		failureThreshold = 3
+	)
 	backoff := time.Second
-	maxBackoff := 30 * time.Second
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
+	consecFails := 0
+	everReady := false
+	probeUnready := true // startup counts as probe-driven unreadiness
 
-		callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	for {
+		callCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 		err := c.GetMe(callCtx)
 		cancel()
-		if err == nil {
-			logger.Info("telegram getMe ok; readiness=ready")
-			r.MarkReady()
+		if ctx.Err() != nil {
 			return
 		}
-		logger.Warn("telegram getMe failed", "err", err, "next_retry_ms", backoff.Milliseconds())
-		r.MarkUnready("telegram getMe failed: " + err.Error())
+
+		var wait time.Duration
+		if err == nil {
+			if probeUnready {
+				logger.Info("telegram getMe ok; readiness=ready")
+				r.MarkReady()
+				probeUnready = false
+			}
+			everReady = true
+			consecFails = 0
+			backoff = time.Second
+			wait = probeInterval
+		} else {
+			consecFails++
+			logger.Warn("telegram getMe failed",
+				"err", err,
+				"consecutive", consecFails,
+				"next_retry_ms", backoff.Milliseconds(),
+			)
+			if !everReady || consecFails >= failureThreshold {
+				r.MarkUnready("telegram getMe failed: " + err.Error())
+				probeUnready = true
+			}
+			wait = backoff
+			if backoff < maxBackoff {
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+		}
 
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(backoff):
-		}
-		if backoff < maxBackoff {
-			backoff *= 2
-			if backoff > maxBackoff {
-				backoff = maxBackoff
-			}
+		case <-time.After(wait):
 		}
 	}
 }

--- a/cmd/alertly/main_test.go
+++ b/cmd/alertly/main_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MaksimRudakov/alertly/internal/server"
+	"github.com/MaksimRudakov/alertly/internal/telegram"
+)
+
+type fakeTelegram struct {
+	getMeErr atomic.Pointer[error]
+}
+
+func (f *fakeTelegram) setGetMeErr(err error) { f.getMeErr.Store(&err) }
+
+func (f *fakeTelegram) GetMe(context.Context) error {
+	if p := f.getMeErr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+func (f *fakeTelegram) SendMessage(context.Context, int64, *int, string, *telegram.SendOptions) (int64, error) {
+	return 0, nil
+}
+func (f *fakeTelegram) GetUpdates(context.Context, int64, time.Duration) ([]telegram.Update, error) {
+	return nil, nil
+}
+func (f *fakeTelegram) AnswerCallbackQuery(context.Context, string, string, bool) error { return nil }
+func (f *fakeTelegram) EditMessageText(context.Context, int64, int64, string, *telegram.InlineKeyboardMarkup) error {
+	return nil
+}
+func (f *fakeTelegram) EditMessageReplyMarkup(context.Context, int64, int64, *telegram.InlineKeyboardMarkup) error {
+	return nil
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+// Startup: unready while getMe fails, ready once it succeeds; the loop keeps
+// probing afterwards and exits on ctx cancel.
+func TestTelegramHealthLoop_StartupAndRecovery(t *testing.T) {
+	fake := &fakeTelegram{}
+	fake.setGetMeErr(errors.New("dial tcp: connection refused"))
+	readiness := server.NewReadiness()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		telegramHealthLoop(ctx, fake, readiness, logger, 20*time.Millisecond)
+		close(done)
+	}()
+
+	waitFor(t, 2*time.Second, func() bool {
+		ready, reason := readiness.IsReady()
+		return !ready && reason != "" && reason != "startup: telegram getMe pending"
+	}, "readiness never went unready with a getMe reason during failing startup")
+
+	fake.setGetMeErr(nil)
+	waitFor(t, 5*time.Second, func() bool {
+		ready, _ := readiness.IsReady()
+		return ready
+	}, "readiness never recovered after getMe started succeeding")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("health loop did not exit on ctx cancel")
+	}
+}

--- a/examples/values-production.yaml
+++ b/examples/values-production.yaml
@@ -3,7 +3,7 @@
 # Install:
 #   helm install alertly alertly/alertly \
 #     --namespace monitoring-system --create-namespace \
-#     --version 0.2.0 \
+#     --version 0.3.0 \
 #     -f examples/values-production.yaml
 #
 # Prerequisites:
@@ -11,8 +11,8 @@
 #     TELEGRAM_BOT_TOKEN and WEBHOOK_AUTH_TOKEN — typically provisioned by
 #     external-secrets, sealed-secrets, or vault-csi.
 #   - stakater/Reloader installed in the cluster (for `reloader.enabled`).
-#   - kube-prometheus-stack (or any operator watching PodMonitor) installed
-#     if you want scraping via the PodMonitor in extraManifests.
+#   - Prometheus Operator CRDs (kube-prometheus-stack) installed for
+#     `metrics.serviceMonitor.enabled` — rendering fails without them.
 
 replicaCount: 1
 
@@ -45,46 +45,35 @@ resources:
     cpu: 200m
     memory: 128Mi
 
-# Spread across zones when the cluster has them; harmless if it does not.
-topologySpreadConstraints:
-  - maxSkew: 1
-    topologyKey: topology.kubernetes.io/zone
-    whenUnsatisfiable: ScheduleAnyway
-    labelSelector:
-      matchLabels:
-        app.kubernetes.io/name: alertly
+# Effective only with replicaCount > 1 — with a single replica there is nothing
+# to spread. Uncomment if you scale out (see replicaCount dedup caveats first).
+# topologySpreadConstraints:
+#   - maxSkew: 1
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: alertly
 
-# Escape hatch for cluster-scoped artifacts we don't template natively
-# (PodMonitor / NetworkPolicy / PDB). Kept here so the chart itself stays
-# minimal and CRD-agnostic.
+# maxUnavailable: 0 protects the per-pod dedup window from voluntary evictions.
+# Caveat: with replicaCount: 1 it blocks node drain until manual intervention.
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 0
+
+metrics:
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    scrapeTimeout: 10s
+    # Adjust to match your Prometheus operator's serviceMonitorSelector.
+    additionalLabels:
+      release: kube-prometheus-stack
+
+# Escape hatch for artifacts the chart does not template natively
+# (e.g. NetworkPolicy). PDB and Prometheus scraping use the native
+# `podDisruptionBudget` / `metrics.serviceMonitor` blocks above.
 extraManifests:
-  - apiVersion: policy/v1
-    kind: PodDisruptionBudget
-    metadata:
-      name: alertly
-    spec:
-      maxUnavailable: 0
-      selector:
-        matchLabels:
-          app.kubernetes.io/name: alertly
-
-  # Adjust `release:` label to match your Prometheus operator selector.
-  - apiVersion: monitoring.coreos.com/v1
-    kind: PodMonitor
-    metadata:
-      name: alertly
-      labels:
-        release: kube-prometheus-stack
-    spec:
-      selector:
-        matchLabels:
-          app.kubernetes.io/name: alertly
-      podMetricsEndpoints:
-        - port: http
-          path: /metrics
-          interval: 30s
-          scrapeTimeout: 10s
-
   - apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/MaksimRudakov/alertly
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/internal/alertmanager/cache.go
+++ b/internal/alertmanager/cache.go
@@ -1,6 +1,7 @@
 package alertmanager
 
 import (
+	"container/list"
 	"sync"
 	"time"
 )
@@ -9,24 +10,27 @@ import (
 // It is populated when alertly forwards a notification to Telegram and is
 // consulted by the callback handler as a fallback when Alertmanager does not
 // return the alert (e.g., already resolved/expired). Eviction is FIFO by
-// insertion order once MaxEntries is reached.
+// insertion order once MaxEntries is reached; removal and eviction are O(1)
+// via a linked list of insertion order.
 type LabelCache struct {
 	mu         sync.Mutex
-	entries    map[string]cacheEntry
-	order      []string
+	entries    map[string]*list.Element
+	order      *list.List // front = oldest inserted
 	ttl        time.Duration
 	maxEntries int
 	now        func() time.Time
 }
 
 type cacheEntry struct {
-	labels    map[string]string
-	expiresAt time.Time
+	fingerprint string
+	labels      map[string]string
+	expiresAt   time.Time
 }
 
 func NewLabelCache(ttl time.Duration, maxEntries int) *LabelCache {
 	return &LabelCache{
-		entries:    make(map[string]cacheEntry),
+		entries:    make(map[string]*list.Element),
+		order:      list.New(),
 		ttl:        ttl,
 		maxEntries: maxEntries,
 		now:        time.Now,
@@ -45,13 +49,22 @@ func (c *LabelCache) Put(fingerprint string, labels map[string]string) {
 		copied[k] = v
 	}
 
-	if _, exists := c.entries[fingerprint]; !exists {
-		c.order = append(c.order, fingerprint)
-		c.evictLocked()
+	if el, exists := c.entries[fingerprint]; exists {
+		entry := el.Value.(*cacheEntry)
+		entry.labels = copied
+		entry.expiresAt = c.now().Add(c.ttl)
+		return
 	}
-	c.entries[fingerprint] = cacheEntry{
-		labels:    copied,
-		expiresAt: c.now().Add(c.ttl),
+	el := c.order.PushBack(&cacheEntry{
+		fingerprint: fingerprint,
+		labels:      copied,
+		expiresAt:   c.now().Add(c.ttl),
+	})
+	c.entries[fingerprint] = el
+	for c.order.Len() > c.maxEntries {
+		oldest := c.order.Front()
+		c.order.Remove(oldest)
+		delete(c.entries, oldest.Value.(*cacheEntry).fingerprint)
 	}
 }
 
@@ -62,12 +75,14 @@ func (c *LabelCache) Get(fingerprint string) (map[string]string, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	entry, ok := c.entries[fingerprint]
+	el, ok := c.entries[fingerprint]
 	if !ok {
 		return nil, false
 	}
+	entry := el.Value.(*cacheEntry)
 	if c.now().After(entry.expiresAt) {
-		c.removeLocked(fingerprint)
+		c.order.Remove(el)
+		delete(c.entries, fingerprint)
 		return nil, false
 	}
 	out := make(map[string]string, len(entry.labels))
@@ -77,20 +92,13 @@ func (c *LabelCache) Get(fingerprint string) (map[string]string, bool) {
 	return out, true
 }
 
-func (c *LabelCache) evictLocked() {
-	for len(c.order) > c.maxEntries {
-		oldest := c.order[0]
-		c.order = c.order[1:]
-		delete(c.entries, oldest)
+// Len returns the current number of cached fingerprints (including entries
+// whose TTL has elapsed but which have not been touched since).
+func (c *LabelCache) Len() int {
+	if c == nil {
+		return 0
 	}
-}
-
-func (c *LabelCache) removeLocked(fingerprint string) {
-	delete(c.entries, fingerprint)
-	for i, fp := range c.order {
-		if fp == fingerprint {
-			c.order = append(c.order[:i], c.order[i+1:]...)
-			return
-		}
-	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
 }

--- a/internal/alertmanager/client.go
+++ b/internal/alertmanager/client.go
@@ -91,6 +91,60 @@ func New(cfg Config) Client {
 	}
 }
 
+// Transient AM failures (restart, rollout, brief network blip) should not turn
+// a button press into a user-visible error, so both calls retry a couple of
+// times. A duplicate silence caused by "created but 5xx on response" is
+// harmless: identical matchers suppress the same alerts.
+const (
+	retryAttempts = 3
+	retryBackoff  = 300 * time.Millisecond
+)
+
+func retryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+// doWithRetry executes build() up to retryAttempts times, retrying network
+// errors, 429 and 5xx with linear backoff. The request is rebuilt per attempt
+// because its body reader is consumed. Returns the status code and the
+// (bounded) response body of the final attempt.
+func (c *client) doWithRetry(ctx context.Context, maxBody int64, build func() (*http.Request, error)) (int, []byte, error) {
+	var lastErr error
+	for attempt := 0; attempt < retryAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return 0, nil, ctx.Err()
+			case <-time.After(time.Duration(attempt) * retryBackoff):
+			}
+		}
+
+		req, err := build()
+		if err != nil {
+			return 0, nil, err
+		}
+		c.cfg.Auth.apply(req)
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			lastErr = err
+			if ctx.Err() != nil {
+				return 0, nil, err
+			}
+			continue
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+		_ = resp.Body.Close()
+
+		if retryableStatus(resp.StatusCode) && attempt < retryAttempts-1 {
+			lastErr = &APIError{StatusCode: resp.StatusCode, Body: string(body)}
+			continue
+		}
+		return resp.StatusCode, body, nil
+	}
+	return 0, nil, lastErr
+}
+
 func (c *client) GetAlertLabels(ctx context.Context, fingerprint string) (map[string]string, error) {
 	if fingerprint == "" {
 		return nil, errors.New("fingerprint is empty")
@@ -108,22 +162,19 @@ func (c *client) GetAlertLabels(ctx context.Context, fingerprint string) (map[st
 	q.Set("inhibited", "true")
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-	c.cfg.Auth.apply(req)
-
-	resp, err := c.http.Do(req)
+	status, body, err := c.doWithRetry(ctx, 1<<20, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("alertmanager get alerts: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &APIError{StatusCode: resp.StatusCode, Body: string(body)}
+	if status < 200 || status >= 300 {
+		return nil, &APIError{StatusCode: status, Body: string(body)}
 	}
 
 	var alerts []alert
@@ -150,23 +201,20 @@ func (c *client) CreateSilence(ctx context.Context, sreq SilenceRequest) (string
 		return "", fmt.Errorf("marshal silence: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
-	if err != nil {
-		return "", fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-	c.cfg.Auth.apply(req)
-
-	resp, err := c.http.Do(req)
+	status, respBody, err := c.doWithRetry(ctx, 1<<16, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return "", fmt.Errorf("alertmanager create silence: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", &APIError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	if status < 200 || status >= 300 {
+		return "", &APIError{StatusCode: status, Body: string(respBody)}
 	}
 
 	var sr silenceResponse

--- a/internal/alertmanager/client_test.go
+++ b/internal/alertmanager/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -149,5 +150,98 @@ func TestMatchersFromLabels(t *testing.T) {
 		if !x.IsEqual || x.IsRegex {
 			t.Errorf("matcher flags wrong: %+v", x)
 		}
+	}
+}
+
+// Transient 5xx must be retried transparently for both the labels lookup and
+// silence creation; a persistent 4xx must not be retried.
+func TestGetAlertLabels_RetriesTransient5xx(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(503)
+			return
+		}
+		_, _ = io.WriteString(w, `[{"fingerprint":"fp","labels":{"alertname":"X"}}]`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, RequestTimeout: 2 * time.Second})
+	labels, err := c.GetAlertLabels(context.Background(), "fp")
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got %v", err)
+	}
+	if labels["alertname"] != "X" {
+		t.Errorf("labels: %#v", labels)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expected 2 attempts, got %d", calls.Load())
+	}
+}
+
+func TestCreateSilence_RetriesTransient5xx(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.WriteHeader(502)
+			return
+		}
+		// The request body must be re-sent intact on retry.
+		var req SilenceRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.Matchers) != 1 {
+			t.Errorf("retry lost request body: err=%v matchers=%+v", err, req.Matchers)
+		}
+		_, _ = io.WriteString(w, `{"silenceID":"s-retry"}`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, RequestTimeout: 2 * time.Second})
+	id, err := c.CreateSilence(context.Background(), SilenceRequest{
+		Matchers: []Matcher{{Name: "alertname", Value: "X", IsEqual: true}},
+	})
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got %v", err)
+	}
+	if id != "s-retry" {
+		t.Errorf("silence id: %s", id)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expected 2 attempts, got %d", calls.Load())
+	}
+}
+
+func TestCreateSilence_NoRetryOn4xx(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(400)
+		_, _ = io.WriteString(w, `invalid matcher`)
+	}))
+	defer srv.Close()
+
+	c := New(Config{URL: srv.URL, RequestTimeout: 2 * time.Second})
+	if _, err := c.CreateSilence(context.Background(), SilenceRequest{}); err == nil {
+		t.Fatal("expected error")
+	}
+	if calls.Load() != 1 {
+		t.Errorf("4xx must not be retried, got %d attempts", calls.Load())
+	}
+}
+
+func TestLabelCache_Len(t *testing.T) {
+	c := NewLabelCache(time.Hour, 10)
+	if c.Len() != 0 {
+		t.Errorf("empty cache Len: %d", c.Len())
+	}
+	c.Put("a", map[string]string{"x": "1"})
+	c.Put("b", map[string]string{"x": "2"})
+	c.Put("a", map[string]string{"x": "3"}) // update, not a new entry
+	if c.Len() != 2 {
+		t.Errorf("Len after 2 distinct puts: %d", c.Len())
+	}
+	var nilCache *LabelCache
+	if nilCache.Len() != 0 {
+		t.Error("nil cache Len should be 0")
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -26,6 +26,7 @@ var (
 	SilencesCreated       *prometheus.CounterVec
 	UpdatesPollErrors     *prometheus.CounterVec
 	DedupSkipped          *prometheus.CounterVec
+	LabelCacheLookups     *prometheus.CounterVec
 )
 
 func Init() *prometheus.Registry {
@@ -104,6 +105,11 @@ func Init() *prometheus.Registry {
 			Help: "Number of notification deliveries suppressed by the in-process dedup cache (caller retry of an already-delivered notification).",
 		}, []string{"source", "chat_id", "status"})
 
+		LabelCacheLookups = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "alertly_label_cache_lookups_total",
+			Help: "Number of label-cache fallback lookups during callback handling, per result (hit/miss).",
+		}, []string{"result"})
+
 		registry.MustRegister(
 			NotificationsReceived,
 			NotificationsSent,
@@ -119,6 +125,7 @@ func Init() *prometheus.Registry {
 			SilencesCreated,
 			UpdatesPollErrors,
 			DedupSkipped,
+			LabelCacheLookups,
 			collectors.NewGoCollector(),
 			collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		)
@@ -129,3 +136,16 @@ func Init() *prometheus.Registry {
 func Registry() *prometheus.Registry { return registry }
 
 func ChatLabel(chatID int64) string { return strconv.FormatInt(chatID, 10) }
+
+// RegisterSizeGauge exposes fn() as a gauge evaluated on scrape. Meant for
+// cache/tracker sizes that otherwise grow invisibly. Call once per name after
+// Init(); duplicate names panic by design (programming error, not runtime state).
+func RegisterSizeGauge(name, help string, fn func() int) {
+	if registry == nil || fn == nil {
+		return
+	}
+	registry.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: name,
+		Help: help,
+	}, func() float64 { return float64(fn()) }))
+}

--- a/internal/server/callback.go
+++ b/internal/server/callback.go
@@ -158,8 +158,10 @@ func (h *CallbackHandler) resolveLabels(ctx context.Context, fingerprint string)
 	}
 	if errors.Is(err, alertmanager.ErrAlertNotFound) {
 		if cached, ok := h.deps.Cache.Get(fingerprint); ok {
+			metrics.LabelCacheLookups.WithLabelValues("hit").Inc()
 			return cached, nil
 		}
+		metrics.LabelCacheLookups.WithLabelValues("miss").Inc()
 		return nil, alertmanager.ErrAlertNotFound
 	}
 	return nil, err
@@ -175,9 +177,10 @@ func (h *CallbackHandler) stripKeyboard(ctx context.Context, cq *telegram.Callba
 }
 
 func (h *CallbackHandler) answer(ctx context.Context, id, text string, showAlert bool) {
-	// Answer must be sent within ~15s or Telegram shows "loading…". Use a short,
-	// context-bounded timeout so a stuck AM does not block the ack.
-	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// Answer must be sent within ~15s or Telegram shows "loading…". Detach from
+	// the parent so the user still gets feedback when the per-callback handle
+	// budget was spent inside an AM call, but keep our own short timeout.
+	cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	if err := h.deps.Telegram.AnswerCallbackQuery(cctx, id, text, showAlert); err != nil {
 		h.deps.Logger.Warn("answerCallbackQuery failed", "err", err)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -107,7 +107,7 @@ func webhookHandler(d webhookDeps) http.HandlerFunc {
 						strconv.FormatInt(target.ChatID, 10), n.Status).Inc()
 					logger.Info("dedup: skip duplicate delivery",
 						"chat_id", target.ChatID,
-						"thread_id", threadIDValue(target.ThreadID),
+						"thread_id", telegram.ThreadIDValue(target.ThreadID),
 						"fingerprint", n.Fingerprint,
 						"status", n.Status,
 					)
@@ -131,7 +131,7 @@ func webhookHandler(d webhookDeps) http.HandlerFunc {
 						targetFailed = true
 						logger.Error("send failed",
 							"chat_id", target.ChatID,
-							"thread_id", threadIDValue(target.ThreadID),
+							"thread_id", telegram.ThreadIDValue(target.ThreadID),
 							"fingerprint", n.Fingerprint,
 							"err", err,
 						)
@@ -184,17 +184,18 @@ func (d webhookDeps) send(ctx context.Context, target notification.ChatTarget, t
 	return 0, err
 }
 
+// isServerError classifies a send failure for readiness accounting: Telegram
+// 5xx and network-level errors count as server-side degradation; 4xx (bad
+// request, chat not found) and caller-driven cancellations do not. 429 is
+// deliberately excluded — flipping readiness on rate limiting would drop the
+// pod from the Service and turn backpressure into an outage.
 func isServerError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
 	var ae *telegram.APIError
 	if errors.As(err, &ae) {
 		return ae.Status() >= 500
 	}
-	return false
-}
-
-func threadIDValue(p *int) any {
-	if p == nil {
-		return nil
-	}
-	return *p
+	return true
 }

--- a/internal/server/keyboard.go
+++ b/internal/server/keyboard.go
@@ -1,10 +1,17 @@
 package server
 
 import (
+	"log/slog"
+
 	"github.com/MaksimRudakov/alertly/internal/alertmanager"
 	"github.com/MaksimRudakov/alertly/internal/notification"
 	"github.com/MaksimRudakov/alertly/internal/telegram"
 )
+
+// maxCallbackDataBytes is the Telegram Bot API limit for
+// InlineKeyboardButton.callback_data. Exceeding it fails the whole
+// sendMessage, not just the button.
+const maxCallbackDataBytes = 64
 
 // AlertmanagerKeyboard attaches a single row of silence buttons to firing
 // alertmanager notifications in allowlisted chats. It also populates the label
@@ -13,6 +20,7 @@ type AlertmanagerKeyboard struct {
 	Durations     []string // ordered, e.g. ["1h", "4h", "24h"]
 	ChatAllowlist []int64
 	Cache         *alertmanager.LabelCache
+	Logger        *slog.Logger
 }
 
 func (k *AlertmanagerKeyboard) Build(target notification.ChatTarget, n notification.Notification, sourceName string) *telegram.SendOptions {
@@ -32,10 +40,25 @@ func (k *AlertmanagerKeyboard) Build(target notification.ChatTarget, n notificat
 
 	silenceRow := make([]telegram.InlineKeyboardButton, 0, len(k.Durations))
 	for _, d := range k.Durations {
+		data := BuildCallbackData(CallbackActionSilence, n.Fingerprint, d)
+		if len(data) > maxCallbackDataBytes {
+			if k.Logger != nil {
+				k.Logger.Warn("silence button skipped: callback_data exceeds Telegram limit",
+					"fingerprint", n.Fingerprint,
+					"duration", d,
+					"bytes", len(data),
+					"limit", maxCallbackDataBytes,
+				)
+			}
+			continue
+		}
 		silenceRow = append(silenceRow, telegram.InlineKeyboardButton{
 			Text:         "🔇 Silence " + d,
-			CallbackData: BuildCallbackData(CallbackActionSilence, n.Fingerprint, d),
+			CallbackData: data,
 		})
+	}
+	if len(silenceRow) == 0 {
+		return nil
 	}
 	return &telegram.SendOptions{
 		ReplyMarkup: &telegram.InlineKeyboardMarkup{

--- a/internal/server/keyboard_test.go
+++ b/internal/server/keyboard_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +46,38 @@ func TestKeyboard_FiringAllowlistedChat(t *testing.T) {
 	}
 	if _, ok := cache.Get("fp"); !ok {
 		t.Error("labels should be cached on keyboard build")
+	}
+}
+
+func TestKeyboard_SkipsOversizedCallbackData(t *testing.T) {
+	longFP := strings.Repeat("f", 80) // "s|<80 chars>|1h" > 64 bytes
+	k := &AlertmanagerKeyboard{
+		Durations:     []string{"1h"},
+		ChatAllowlist: []int64{-100},
+		Cache:         alertmanager.NewLabelCache(time.Hour, 10),
+	}
+	opts := k.Build(
+		notification.ChatTarget{ChatID: -100},
+		notification.Notification{Status: "firing", Fingerprint: longFP, Labels: map[string]string{"a": "1"}},
+		"alertmanager",
+	)
+	if opts != nil {
+		t.Error("keyboard with only oversized callback_data buttons should be dropped entirely")
+	}
+
+	// A normal fingerprint on the same builder still yields buttons.
+	opts = k.Build(
+		notification.ChatTarget{ChatID: -100},
+		notification.Notification{Status: "firing", Fingerprint: "fp", Labels: map[string]string{"a": "1"}},
+		"alertmanager",
+	)
+	if opts == nil {
+		t.Fatal("expected keyboard for normal fingerprint")
+	}
+	for _, b := range opts.ReplyMarkup.InlineKeyboard[0] {
+		if len(b.CallbackData) > maxCallbackDataBytes {
+			t.Errorf("callback_data exceeds limit: %d bytes", len(b.CallbackData))
+		}
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -406,7 +408,9 @@ func TestIsServerError(t *testing.T) {
 		want bool
 	}{
 		{"nil error returns false", nil, false},
-		{"non-api error returns false", context.Canceled, false},
+		{"canceled context returns false", context.Canceled, false},
+		{"deadline exceeded returns false", fmt.Errorf("send: %w", context.DeadlineExceeded), false},
+		{"network error returns true", errors.New("dial tcp: connection refused"), true},
 		{"api 400 returns false", &telegram.APIError{StatusCode: 400}, false},
 		{"api 429 returns false", &telegram.APIError{StatusCode: 429}, false},
 		{"api 500 returns true", &telegram.APIError{StatusCode: 500}, true},

--- a/internal/server/updates.go
+++ b/internal/server/updates.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -17,6 +18,9 @@ type UpdatesPoller struct {
 	Handler     *CallbackHandler
 	Logger      *slog.Logger
 	PollTimeout time.Duration
+	// HandleTimeout bounds processing of a single callback_query; zero means
+	// callbackHandleTimeout.
+	HandleTimeout time.Duration
 
 	offset int64
 }
@@ -24,6 +28,10 @@ type UpdatesPoller struct {
 func (p *UpdatesPoller) Run(ctx context.Context) {
 	backoff := time.Second
 	const maxBackoff = 30 * time.Second
+	handleTimeout := p.HandleTimeout
+	if handleTimeout <= 0 {
+		handleTimeout = callbackHandleTimeout
+	}
 
 	p.Logger.Info("telegram updates poller started", "poll_timeout", p.PollTimeout)
 	defer p.Logger.Info("telegram updates poller stopped")
@@ -44,7 +52,8 @@ func (p *UpdatesPoller) Run(ctx context.Context) {
 				return
 			}
 			reason := "network"
-			if ae, ok := asTelegramAPIError(err); ok {
+			var ae *telegram.APIError
+			if errors.As(err, &ae) {
 				reason = "api_" + httpStatusClass(ae.Status())
 			}
 			metrics.UpdatesPollErrors.WithLabelValues(reason).Inc()
@@ -71,30 +80,22 @@ func (p *UpdatesPoller) Run(ctx context.Context) {
 			if u.CallbackQuery == nil {
 				continue
 			}
-			// Process each callback in the foreground; AM calls are quick and
-			// serialisation gives predictable ordering without extra locking.
-			p.Handler.Handle(ctx, u.CallbackQuery)
+			// Process each callback in the foreground; serialisation gives
+			// predictable ordering without extra locking. The per-callback
+			// timeout keeps one stuck AM/Telegram call from stalling the loop:
+			// without it, EditMessageReplyMarkup would retry with backoff for
+			// minutes on an undeadlined context.
+			hctx, hcancel := context.WithTimeout(ctx, handleTimeout)
+			p.Handler.Handle(hctx, u.CallbackQuery)
+			hcancel()
 		}
 	}
 }
 
-func asTelegramAPIError(err error) (*telegram.APIError, bool) {
-	if err == nil {
-		return nil, false
-	}
-	type unwrapper interface{ Unwrap() error }
-	for e := err; e != nil; {
-		if ae, ok := e.(*telegram.APIError); ok {
-			return ae, true
-		}
-		u, ok := e.(unwrapper)
-		if !ok {
-			return nil, false
-		}
-		e = u.Unwrap()
-	}
-	return nil, false
-}
+// callbackHandleTimeout bounds the processing of a single callback_query.
+// Telegram expects answerCallbackQuery within ~15s; anything slower already
+// shows a spinner to the user, so there is no point retrying past this budget.
+const callbackHandleTimeout = 15 * time.Second
 
 func httpStatusClass(code int) string {
 	switch {

--- a/internal/server/updates_test.go
+++ b/internal/server/updates_test.go
@@ -135,3 +135,87 @@ func TestUpdatesPoller_ShutdownOnCtxCancel(t *testing.T) {
 		t.Fatal("poller did not exit within 3s of cancel")
 	}
 }
+
+// A stuck Alertmanager must not stall the poll loop: the per-callback timeout
+// bounds Handle, the user still gets an answer, and the next update is
+// processed promptly.
+func TestUpdatesPoller_HandleTimeoutUnblocksLoop(t *testing.T) {
+	var answerCalls atomic.Int32
+	var secondCallbackSeen atomic.Int32
+
+	tgSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/getUpdates"):
+			var req struct {
+				Offset int64 `json:"offset"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			switch {
+			case req.Offset <= 1:
+				_, _ = io.WriteString(w, `{"ok":true,"result":[{"update_id":1,"callback_query":{"id":"cb1","from":{"id":42},"message":{"message_id":7,"chat":{"id":-100}},"data":"s|fp1|1h"}}]}`)
+			case req.Offset == 2:
+				secondCallbackSeen.Add(1)
+				_, _ = io.WriteString(w, `{"ok":true,"result":[]}`)
+			default:
+				_, _ = io.WriteString(w, `{"ok":true,"result":[]}`)
+			}
+		case strings.HasSuffix(r.URL.Path, "/answerCallbackQuery"):
+			answerCalls.Add(1)
+			_, _ = io.WriteString(w, `{"ok":true,"result":true}`)
+		case strings.HasSuffix(r.URL.Path, "/editMessageReplyMarkup"):
+			_, _ = io.WriteString(w, `{"ok":true,"result":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer tgSrv.Close()
+
+	// AM hangs until the request context is canceled — simulates a stuck AM.
+	amSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer amSrv.Close()
+
+	tg := telegram.New(telegram.Config{APIURL: tgSrv.URL, Token: "t", RequestTimeout: 2 * time.Second, MaxAttempts: 1},
+		telegram.NewLimiter(1000, 1000), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	am := alertmanager.New(alertmanager.Config{URL: amSrv.URL, RequestTimeout: 30 * time.Second})
+	tracker := NewButtonTracker(time.Hour)
+	tracker.Register(-100, 7, "fp1")
+	handler := NewCallbackHandler(CallbackDeps{
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Telegram:      tg,
+		AM:            am,
+		Cache:         alertmanager.NewLabelCache(time.Hour, 10),
+		Tracker:       tracker,
+		ChatAllowlist: []int64{-100},
+		Durations:     map[string]time.Duration{"1h": time.Hour},
+	})
+	poller := &UpdatesPoller{
+		Client:        tg,
+		Handler:       handler,
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		PollTimeout:   50 * time.Millisecond,
+		HandleTimeout: 200 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { poller.Run(ctx); close(done) }()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if secondCallbackSeen.Load() >= 1 && answerCalls.Load() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if secondCallbackSeen.Load() < 1 {
+		t.Error("poller stayed blocked on stuck AM: never advanced past the first callback")
+	}
+	if answerCalls.Load() < 1 {
+		t.Error("user never got an answer for the timed-out callback")
+	}
+}

--- a/internal/source/kubewatch.go
+++ b/internal/source/kubewatch.go
@@ -75,7 +75,10 @@ func kwToNotification(meta kwEventMeta, text string, ts time.Time) notification.
 	}
 
 	title := buildKWTitle(meta)
-	fp := fingerprint(meta.Kind, meta.Namespace, meta.Name, meta.Reason, meta.Type)
+	// Include the message body: dedup must absorb caller retries (identical
+	// payload), not collapse distinct events on the same object — e.g. two
+	// CrashLoopBackOff messages with different restart counts within the TTL.
+	fp := fingerprint(meta.Kind, meta.Namespace, meta.Name, meta.Reason, meta.Type, body)
 
 	return notification.Notification{
 		Source:      "kubewatch",

--- a/internal/source/kubewatch_test.go
+++ b/internal/source/kubewatch_test.go
@@ -50,6 +50,27 @@ func TestKubewatchFingerprintStable(t *testing.T) {
 	}
 }
 
+// Same object+reason but different message must not share a fingerprint —
+// otherwise dedup collapses distinct events (e.g. CrashLoopBackOff with
+// changing restart counts) for the whole TTL.
+func TestKubewatchFingerprintIncludesMessage(t *testing.T) {
+	payload := func(msg string) []byte {
+		return []byte(`{"eventmeta":{"kind":"Pod","name":"api","namespace":"prod","reason":"BackOff","type":"Warning"},"text":"` + msg + `","time":"2026-01-01T00:00:00Z"}`)
+	}
+	a, err := NewKubewatch().Parse(payload("restart count 1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := NewKubewatch().Parse(payload("restart count 2"))
+	if a[0].Fingerprint == b[0].Fingerprint {
+		t.Error("different messages should produce different fingerprints")
+	}
+	c, _ := NewKubewatch().Parse(payload("restart count 1"))
+	if a[0].Fingerprint != c[0].Fingerprint {
+		t.Error("identical payloads (caller retry) should share a fingerprint")
+	}
+}
+
 func TestKubewatchInvalid(t *testing.T) {
 	if _, err := NewKubewatch().Parse([]byte("not json")); err == nil {
 		t.Error("expected error")

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -42,10 +43,14 @@ type Config struct {
 }
 
 type client struct {
-	cfg     Config
-	http    *http.Client
-	limiter *Limiter
-	log     *slog.Logger
+	cfg  Config
+	http *http.Client
+	// pollHTTP has no client-level timeout: long-poll duration is bounded by the
+	// request context in GetUpdates. A dedicated client keeps its keep-alive
+	// connection to Telegram warm between polls.
+	pollHTTP *http.Client
+	limiter  *Limiter
+	log      *slog.Logger
 }
 
 func New(cfg Config, limiter *Limiter, logger *slog.Logger) Client {
@@ -65,10 +70,11 @@ func New(cfg Config, limiter *Limiter, logger *slog.Logger) Client {
 		cfg.MaxBackoff = 60 * time.Second
 	}
 	return &client{
-		cfg:     cfg,
-		http:    &http.Client{Timeout: cfg.RequestTimeout},
-		limiter: limiter,
-		log:     logger,
+		cfg:      cfg,
+		http:     &http.Client{Timeout: cfg.RequestTimeout},
+		pollHTTP: &http.Client{},
+		limiter:  limiter,
+		log:      logger,
 	}
 }
 
@@ -97,7 +103,7 @@ func (c *client) SendMessage(ctx context.Context, chatID int64, threadID *int, t
 	if c.cfg.DryRun {
 		c.log.Info("dry run: skip telegram send",
 			"chat_id", chatID,
-			"thread_id", threadIDValue(threadID),
+			"thread_id", ThreadIDValue(threadID),
 			"text_len", len(text),
 		)
 		return 0, nil
@@ -190,7 +196,8 @@ func (c *client) callWithRetry(ctx context.Context, endpoint string, body []byte
 		wait := backoff(c.cfg.InitialBackoff, c.cfg.MaxBackoff, attempt)
 		var ae *APIError
 		if reason == "429" {
-			if as := asAPIError(err); as != nil && as.RetryAfter > 0 {
+			var as *APIError
+			if errors.As(err, &as) && as.RetryAfter > 0 {
 				wait = as.RetryAfter
 				if wait > c.cfg.MaxBackoff {
 					wait = c.cfg.MaxBackoff
@@ -284,22 +291,9 @@ func (c *client) callOnce(ctx context.Context, endpoint string, body []byte) ([]
 	return nil, ae
 }
 
-func asAPIError(err error) *APIError {
-	for e := err; e != nil; {
-		if ae, ok := e.(*APIError); ok {
-			return ae
-		}
-		type unwrapper interface{ Unwrap() error }
-		if u, ok := e.(unwrapper); ok {
-			e = u.Unwrap()
-			continue
-		}
-		return nil
-	}
-	return nil
-}
-
-func threadIDValue(p *int) any {
+// ThreadIDValue renders an optional topic thread ID for structured logging:
+// nil stays nil instead of a pointer address.
+func ThreadIDValue(p *int) any {
 	if p == nil {
 		return nil
 	}

--- a/internal/telegram/updates.go
+++ b/internal/telegram/updates.go
@@ -75,6 +75,13 @@ type editMessageReplyMarkupRequest struct {
 }
 
 func (c *client) GetUpdates(ctx context.Context, offset int64, timeout time.Duration) ([]Update, error) {
+	// pollHTTP carries no client-level timeout; make sure the request cannot
+	// hang forever even when the caller passed an unbounded context.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout+c.cfg.RequestTimeout)
+		defer cancel()
+	}
 	req := getUpdatesRequest{
 		Offset:         offset,
 		Timeout:        int(timeout.Seconds()),
@@ -92,9 +99,7 @@ func (c *client) GetUpdates(ctx context.Context, offset int64, timeout time.Dura
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	// Use a dedicated HTTP client so long-poll timeout does not clash with RequestTimeout.
-	pollClient := &http.Client{Timeout: timeout + c.cfg.RequestTimeout}
-	resp, err := pollClient.Do(httpReq)
+	resp, err := c.pollHTTP.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("getUpdates: %w", err)
 	}


### PR DESCRIPTION
## Summary

Reliability, observability and supply-chain hardening pass + release bump to **v0.3.0** (chart `0.3.0`, appVersion `0.3.0`). No config changes required; all new chart features are opt-in. Full details in `CHANGELOG.md` → `[0.3.0]`.

### Reliability
- Per-callback handle timeout (15s) — a stuck AM/Telegram call no longer stalls the updates poller; user always gets an answer (detached context).
- Graceful shutdown waits for background workers (poller, sweepers, health probe, dedup) up to `server.shutdown_timeout`.
- Continuous Telegram health probe (`getMe` every 60s, 3 consecutive failures → unready); network send errors count toward the readiness window.
- Alertmanager client retries network/429/5xx (3 attempts, linear backoff).
- Kubewatch fingerprint includes the event message — dedup absorbs only identical redeliveries.
- Oversized `callback_data` (>64 bytes) skips the button instead of failing the whole `sendMessage`.
- `getUpdates` reuses a dedicated keep-alive HTTP client.

### Observability
- `alertly_label_cache_lookups_total{result}` + gauges `alertly_{dedup_cache,button_tracker,label_cache}_entries`.

### Helm
- Native `podDisruptionBudget.*` and `metrics.serviceMonitor.*` toggles (off by default).

### Supply chain / CI
- All actions pinned to commit SHAs; base images pinned by digest; Go toolchain → 1.26.4 (fixes stdlib CVEs flagged by govulncheck).
- New workflows: CodeQL, OpenSSF Scorecard; new CI jobs: govulncheck, kind-based chart install test.

### Docs
- README: silence-buttons section, fixed comparison/metrics tables, AM auth env vars, new troubleshooting rows; CLAUDE.md updated for Phase 2b.

## Test plan
- [x] `go test -race ./...` — all packages ok (7 new tests: poller handle-timeout, health loop, AM retry ×3, oversized callback_data, kubewatch fingerprint, LabelCache.Len)
- [x] `make lint` / `gofmt` / `make build` clean; `make vuln` — 0 vulnerabilities
- [x] `helm lint` + `helm template` incl. new toggles and values-production.yaml
- [x] Local DRY_RUN smoke: `/healthz`, `/readyz`, webhook 200, duplicate → 204 (dedup), new gauges visible, clean shutdown
- [ ] First run of new CI jobs (chart-install, govulncheck, CodeQL) happens in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)