### PR TITLE
chore(release): v0.4.0 (chart 0.4.0, appVersion 0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-06
+
+In-chat silence UX round-trip (create → undo, configurable scope) and a generic JSON source for arbitrary senders. Backward compatible: defaults preserve existing behaviour; undo only affects deployments with `updates.enabled=true`.
+
 ### Added
 - **Generic webhook source** (`POST /v1/generic/{chats}`): alertly's own JSON contract (`title`, `body`, `severity`, `status`, `fingerprint`, `labels`, `annotations`, `links`, `timestamp`; single object or array up to 100). Any tool that can POST JSON — GitLab CI, Jira automation, ArgoCD notifications webhook, scripts — gets dedup, splitting, threads and rate limiting. Fingerprint is content-hashed when absent, so sender retries are absorbed. README documents the contract with GitLab/ArgoCD/Jira examples.
 - **↩️ Undo button**: after a silence is created the keyboard is replaced with a short-lived Undo button that deletes the silence via `DELETE /api/v2/silence/{id}`. Window is `updates.undo_window` (default `5m`, `0` disables, max `1h`); state is in-memory with the same strict expire-on-restart policy. Metrics: `alertly_silences_deleted_total{status}`, gauge `alertly_undo_tracker_entries`.
@@ -107,7 +111,8 @@ Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to kee
 - Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
 - New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/MaksimRudakov/alertly/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/MaksimRudakov/alertly/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/MaksimRudakov/alertly/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/MaksimRudakov/alertly/compare/v0.0.3...v0.1.0

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ helm search repo alertly
 OCI (GitHub Container Registry, no `helm repo add` needed):
 
 ```bash
-helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.3.0
+helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.4.0
 ```
 
 ### Install
@@ -65,7 +65,7 @@ Quick install with tokens passed directly (fine for a lab / personal cluster —
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.3.0 \
+  --version 0.4.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -75,7 +75,7 @@ Or from OCI:
 ```bash
 helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.3.0 \
+  --version 0.4.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -101,7 +101,7 @@ Then install referencing it:
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.3.0 \
+  --version 0.4.0 \
   --set secret.create=false \
   --set secret.existingSecret=alertly-tokens \
   --set reloader.enabled=true   # optional: auto-restart on Secret/ConfigMap changes
@@ -118,15 +118,15 @@ Both the chart tarball (attached to the GitHub Release) and the OCI chart manife
 cosign verify \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/maksimrudakov/charts/alertly:0.3.0
+  ghcr.io/maksimrudakov/charts/alertly:0.4.0
 
-# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.3.0 release)
+# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.4.0 release)
 cosign verify-blob \
-  --certificate alertly-0.3.0.tgz.pem \
-  --signature alertly-0.3.0.tgz.sig \
+  --certificate alertly-0.4.0.tgz.pem \
+  --signature alertly-0.4.0.tgz.sig \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  alertly-0.3.0.tgz
+  alertly-0.4.0.tgz
 ```
 
 The container image `ghcr.io/maksimrudakov/alertly` is signed the same way.

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 

--- a/examples/values-production.yaml
+++ b/examples/values-production.yaml
@@ -3,7 +3,7 @@
 # Install:
 #   helm install alertly alertly/alertly \
 #     --namespace monitoring-system --create-namespace \
-#     --version 0.3.0 \
+#     --version 0.4.0 \
 #     -f examples/values-production.yaml
 #
 # Prerequisites:


### PR DESCRIPTION
## Summary

Release bump to **v0.4.0** (chart `0.4.0`, appVersion `0.4.0`) for the features merged in #19:

- ↩️ **Undo silence** button (`updates.undo_window`, default 5m)
- Configurable silence scope (`updates.silence_matchers`)
- **Generic webhook source** `POST /v1/generic/{chats}` (GitLab CI / Jira / ArgoCD / scripts)

Changes in this PR: Chart.yaml version+appVersion, README/examples version references, CHANGELOG `[Unreleased]` → `[0.4.0] - 2026-07-06`.

After merge: tag `v0.4.0` triggers the release workflow (goreleaser, multi-arch image, cosign, chart publish).

## Test plan
- [x] Feature CI already green in #19 (18 checks)
- [x] `helm lint` clean after bump
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)