### PR TITLE
chore(release): v0.5.0 (chart 0.5.0, appVersion 0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-30
+
+Read-only chat-ops (`/status`) and supply-chain/CI hardening. First tagged release since 0.3.0 — the 0.4.0 changelog entry below was merged to `main` but never tagged, so 0.5.0 artifacts are the first to include both feature sets. Backward compatible: commands are off by default.
+
+### Added
+- **`/status` chat-ops command** (`updates.commands.enabled`, requires `updates.enabled`): the long-poll loop additionally requests `message` updates and answers `/status` in allowlisted chats with alertly self-health — version/commit, uptime, readiness (with reason when unready), age of the last Telegram check and in-memory cache sizes (dedup, silence/undo buttons, label cache). Same `chat_allowlist`/`user_allowlist` as silence buttons; unknown commands and non-allowlisted chats are ignored silently; replies follow forum topic threads. New metric: `alertly_commands_received_total{command,status}`.
+- `examples/values-minimal.yaml` — Helm quick-start values.
+
+### Changed
+- Go toolchain 1.26.4 → 1.26.5 and `golang:1.26-alpine` base image digest refreshed (fixes CVE-2026-39822, `os.Root` symlink traversal, HIGH).
+- `release.yaml` workflow: top-level `GITHUB_TOKEN` permissions reduced to `contents: read`, write scopes moved to job level (OpenSSF Scorecard Token-Permissions).
+
 ## [0.4.0] - 2026-07-06
 
 In-chat silence UX round-trip (create → undo, configurable scope) and a generic JSON source for arbitrary senders. Backward compatible: defaults preserve existing behaviour; undo only affects deployments with `updates.enabled=true`.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ helm search repo alertly
 OCI (GitHub Container Registry, no `helm repo add` needed):
 
 ```bash
-helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.4.0
+helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.5.0
 ```
 
 ### Install
@@ -66,7 +66,7 @@ Quick install with tokens passed directly (fine for a lab / personal cluster —
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.4.0 \
+  --version 0.5.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -76,7 +76,7 @@ Or from OCI:
 ```bash
 helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.4.0 \
+  --version 0.5.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -102,7 +102,7 @@ Then install referencing it:
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.4.0 \
+  --version 0.5.0 \
   --set secret.create=false \
   --set secret.existingSecret=alertly-tokens \
   --set reloader.enabled=true   # optional: auto-restart on Secret/ConfigMap changes
@@ -119,15 +119,15 @@ Both the chart tarball (attached to the GitHub Release) and the OCI chart manife
 cosign verify \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/maksimrudakov/charts/alertly:0.4.0
+  ghcr.io/maksimrudakov/charts/alertly:0.5.0
 
-# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.4.0 release)
+# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.5.0 release)
 cosign verify-blob \
-  --certificate alertly-0.4.0.tgz.pem \
-  --signature alertly-0.4.0.tgz.sig \
+  --certificate alertly-0.5.0.tgz.pem \
+  --signature alertly-0.5.0.tgz.sig \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  alertly-0.4.0.tgz
+  alertly-0.5.0.tgz
 ```
 
 The container image `ghcr.io/maksimrudakov/alertly` is signed the same way.

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 

--- a/examples/values-production.yaml
+++ b/examples/values-production.yaml
@@ -3,7 +3,7 @@
 # Install:
 #   helm install alertly alertly/alertly \
 #     --namespace monitoring-system --create-namespace \
-#     --version 0.4.0 \
+#     --version 0.5.0 \
 #     -f examples/values-production.yaml
 #
 # Prerequisites:


### PR DESCRIPTION
Release prep for **v0.5.0** — read-only chat-ops (`/status`, #25) + supply-chain/CI hardening.

Note: 0.4.0 (#21) was merged to main but the tag was never pushed, so no 0.4.0 artifacts exist — v0.5.0 will be the first tagged release since 0.3.0 and ships both feature sets. The 0.4.0 changelog entry stays as-is for history.

- `Chart.yaml`: version/appVersion → 0.5.0 (chart README regenerated via helm-docs)
- `CHANGELOG.md`: [0.5.0] section
- README/values-production: install examples bumped to 0.5.0

After merge: push tag `v0.5.0` → release workflow publishes image + chart (OCI/Pages), cosign-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)