### PR TITLE
chore(release): v0.6.0 (chart 0.6.0, appVersion 0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-30
+
+`/status` grows delivery-pipeline diagnostics: one command now answers «the alert chat went quiet — is Alertmanager down, is Prometheus down, or is it genuinely quiet?».
+
 ### Added
 - **/status pipeline diagnostics** (`updates.commands.status.*`): the reply now includes an Alertmanager section — AM version/cluster state via `GET /api/v2/status`, firing/silenced alert counts, a **Watchdog deadman check** (always-firing alert present and fresh in AM ⇒ Prometheus → AM pipeline alive; name configurable via `watchdog_alert`, stale threshold 15m) and last webhook received / last Telegram delivery timestamps. Distinguishes «AM down», «Prometheus down» and «genuinely quiet» when an alert chat goes silent. Per-call AM budget `pipeline_timeout` (default 4s).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ helm search repo alertly
 OCI (GitHub Container Registry, no `helm repo add` needed):
 
 ```bash
-helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.5.0
+helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.6.0
 ```
 
 ### Install
@@ -66,7 +66,7 @@ Quick install with tokens passed directly (fine for a lab / personal cluster —
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.5.0 \
+  --version 0.6.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -76,7 +76,7 @@ Or from OCI:
 ```bash
 helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.5.0 \
+  --version 0.6.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -102,7 +102,7 @@ Then install referencing it:
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.5.0 \
+  --version 0.6.0 \
   --set secret.create=false \
   --set secret.existingSecret=alertly-tokens \
   --set reloader.enabled=true   # optional: auto-restart on Secret/ConfigMap changes
@@ -119,15 +119,15 @@ Both the chart tarball (attached to the GitHub Release) and the OCI chart manife
 cosign verify \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/maksimrudakov/charts/alertly:0.5.0
+  ghcr.io/maksimrudakov/charts/alertly:0.6.0
 
-# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.5.0 release)
+# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.6.0 release)
 cosign verify-blob \
-  --certificate alertly-0.5.0.tgz.pem \
-  --signature alertly-0.5.0.tgz.sig \
+  --certificate alertly-0.6.0.tgz.pem \
+  --signature alertly-0.6.0.tgz.sig \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  alertly-0.5.0.tgz
+  alertly-0.6.0.tgz
 ```
 
 The container image `ghcr.io/maksimrudakov/alertly` is signed the same way.

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.6.0
+appVersion: "0.6.0"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 

--- a/examples/values-production.yaml
+++ b/examples/values-production.yaml
@@ -3,7 +3,7 @@
 # Install:
 #   helm install alertly alertly/alertly \
 #     --namespace monitoring-system --create-namespace \
-#     --version 0.5.0 \
+#     --version 0.6.0 \
 #     -f examples/values-production.yaml
 #
 # Prerequisites:


### PR DESCRIPTION
Release prep for **v0.6.0** — /status pipeline diagnostics (#28): AM health via /api/v2/status, Watchdog deadman check, alert counts, last webhook/delivery timestamps; Last-Telegram-check freshness fix, short commit hash.

- Chart.yaml: version/appVersion → 0.6.0 (chart README via helm-docs)
- CHANGELOG: [0.6.0] section
- README/values-production examples bumped

After merge: tag v0.6.0 → release workflow publishes signed image + chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)