### PR TITLE
chore(release): v0.7.0 (chart 0.7.0, appVersion 0.7.0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,15 +1,18 @@
 name: CI
 
+# pull_request only: a push trigger for feature branches would start a second,
+# identical run per push. Cancelling that twin via concurrency is not an option
+# either — the repo's required status checks then see the cancelled run and
+# block the merge. Branches without an open PR get their CI when the PR opens.
 on:
   pull_request:
-  push:
-    branches-ignore: [main]
 
 permissions:
   contents: read
 
+# Superseded pushes to the same PR cancel the older run.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-28
+
+Hardening release: the Telegram delivery path loses three long-standing bugs (token in logs, a retry-deadline mechanism that never fired, message splitting Telegram could reject), every in-memory registry and API call gains a bound, and webhooks get an optional chat allowlist. Backward compatible: every new knob defaults to previous behaviour except the 100-alert payload cap (mirrors the generic source) and tightened HTTP header/timeout defaults.
+
 ### Added
 - **`updates.button_tracker_max`** (default 10000) bounds the in-memory silence/undo button trackers with FIFO eviction — previously they grew without limit for the full `button_ttl` (8h default) under a steady stream of firing alerts. An evicted button behaves exactly like the restart case: it stays on screen, a click is rejected and the keyboard stripped.
 - **`server.idle_timeout`** (120s) and **`server.read_header_timeout`** (5s): explicit HTTP server timeouts. Previously both fell back to `read_timeout` (10s), which silently churned Alertmanager's keep-alive connections every 10s of quiet; request headers are now also capped at 64 KiB (down from net/http's 1 MB default).
@@ -23,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - **The rate limiter now covers every chat-addressed API call and every retry attempt.** `editMessageText`/`editMessageReplyMarkup` (keyboard strips, sweeper passes) and `answerCallbackQuery` went straight to the API — one sweep over a pile of expired buttons was an unthrottled burst; and retries inside a single send bypassed the quota taken once up front. The limiter wait now happens per attempt inside the retry loop; edits consume global + per-chat quota, callback answers global only. `getMe` (health probe) and `getUpdates` (long poll) stay unlimited.
 - **A caller-supplied `X-Request-Id` is validated** (`[A-Za-z0-9._-]`, max 64 chars) before being echoed into logs and the response header; anything else is replaced with a generated UUID, so a client cannot inject structured-log noise or terminal escapes through the header.
 - **A panic in a callback/command handler no longer kills the process.** The updates poller runs outside the HTTP stack, so `recoverMiddleware` never covered it; a panicking handler is now logged with its stack and the poll loop continues.
+
+### Changed
+- Dependencies: `prometheus/client_golang` 1.23.2 → 1.24.1; GitHub Actions bumped across workflows (checkout v7, setup-go v7, trivy-action 0.36, codeql-action 4.37.8, cosign-installer v4, buildx/login-action refreshes); `distroless/static-debian12` base digest refreshed.
+- CI runs once per push: the `push` trigger for feature branches is gone (`pull_request` covers every push to an open PR), halving CI time per push. Superseded pushes to the same PR cancel the older run.
 
 ## [0.6.0] - 2026-07-30
 
@@ -152,7 +160,10 @@ Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to kee
 - Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
 - New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/MaksimRudakov/alertly/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/MaksimRudakov/alertly/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/MaksimRudakov/alertly/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/MaksimRudakov/alertly/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/MaksimRudakov/alertly/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/MaksimRudakov/alertly/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ helm search repo alertly
 OCI (GitHub Container Registry, no `helm repo add` needed):
 
 ```bash
-helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.6.0
+helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.7.0
 ```
 
 ### Install
@@ -66,7 +66,7 @@ Quick install with tokens passed directly (fine for a lab / personal cluster —
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.6.0 \
+  --version 0.7.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -76,7 +76,7 @@ Or from OCI:
 ```bash
 helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.6.0 \
+  --version 0.7.0 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -102,7 +102,7 @@ Then install referencing it:
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.6.0 \
+  --version 0.7.0 \
   --set secret.create=false \
   --set secret.existingSecret=alertly-tokens \
   --set reloader.enabled=true   # optional: auto-restart on Secret/ConfigMap changes
@@ -119,15 +119,15 @@ Both the chart tarball (attached to the GitHub Release) and the OCI chart manife
 cosign verify \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/maksimrudakov/charts/alertly:0.6.0
+  ghcr.io/maksimrudakov/charts/alertly:0.7.0
 
-# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.6.0 release)
+# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.7.0 release)
 cosign verify-blob \
-  --certificate alertly-0.6.0.tgz.pem \
-  --signature alertly-0.6.0.tgz.sig \
+  --certificate alertly-0.7.0.tgz.pem \
+  --signature alertly-0.7.0.tgz.sig \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  alertly-0.6.0.tgz
+  alertly-0.7.0.tgz
 ```
 
 The container image `ghcr.io/maksimrudakov/alertly` is signed the same way.

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0
+appVersion: "0.7.0"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 

--- a/examples/values-production.yaml
+++ b/examples/values-production.yaml
@@ -3,7 +3,7 @@
 # Install:
 #   helm install alertly alertly/alertly \
 #     --namespace monitoring-system --create-namespace \
-#     --version 0.6.0 \
+#     --version 0.7.0 \
 #     -f examples/values-production.yaml
 #
 # Prerequisites:


### PR DESCRIPTION
## Summary

Release prep for **v0.7.0**, in the style of the v0.6.0 release PR (#29). Two commits:

1. **`ci: run once per push (pull_request trigger only)`** — every push to a PR branch started two identical CI runs (push trigger + pull_request trigger). The existing `concurrency` group never deduplicated the pair: push runs carry `refs/heads/<branch>` while pull_request runs carry `refs/pull/<n>/merge`. Cancelling the twin across event types is not an option either — this repo's **required status checks then count the cancelled run and block the merge** (verified on this very PR's first head: "7 of 7 required status checks are cancelled"). So the push trigger is dropped instead: `pull_request` alone covers every push to an open PR, which is where required checks are consumed; branches without a PR get their CI when the PR opens. The concurrency group (now keyed by `github.head_ref`) still cancels superseded pushes to the same PR.

2. **`chore(release): v0.7.0`**:
   - `CHANGELOG.md`: `[Unreleased]` → `## [0.7.0] - 2026-08-28` with a release intro; dependency bumps (#30, #31, #22) and the CI change recorded under *Changed*; the stale compare links at the bottom fixed (`Unreleased` now compares from `v0.7.0`; `0.7.0`/`0.6.0`/`0.5.0` links added — they had been stuck at `v0.4.0`).
   - `charts/alertly/Chart.yaml`: `version` and `appVersion` → `0.7.0`.
   - `README.md` / `examples/values-production.yaml`: `0.6.0` version strings in the install/verify examples → `0.7.0`.
   - `charts/alertly/README.md`: regenerated with helm-docs (version badges).

After this merges, the `v0.7.0` tag will be pushed at the merge commit to trigger the release workflow (goreleaser, multi-arch image, cosign signing, chart publish). Note for that run: #31 bumped `cosign-installer` v3→v4 and `checkout` in `release.yaml`, which PR CI does not exercise — the tag run is their first real test.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / chore
- [x] CI / build

## Checklist

- [x] `make lint` passes — `go vet ./...` + `gofmt -l .` clean locally (golangci-lint binary incompatible with the Go 1.26 toolchain in this environment; CI runs the real linter)
- [x] `make test` passes (with `-race`) — 8/8 packages
- [x] Tests added or updated for behavior changes — no behavior changes; version/docs/CI-config only
- [x] `CHANGELOG.md` updated under `## [Unreleased]` — content moved to `## [0.7.0]`
- [x] No secrets, tokens, or PII in diff
