### PR TITLE
fix(ci): sign chart tarballs with cosign v3 bundle format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,14 +135,16 @@ jobs:
             tag="${name}-${version}"
             tgz="/tmp/${tag}.tgz"
             helm package "$chart" -d /tmp
+            # cosign v3 emits a Sigstore bundle; --output-signature/--output-certificate
+            # are deprecated no-ops there and an empty --bundle path aborts signing.
             cosign sign-blob --yes \
-              --output-signature "${tgz}.sig" \
-              --output-certificate "${tgz}.pem" \
+              --new-bundle-format \
+              --bundle "${tgz}.bundle" \
               "${tgz}"
             # skip_existing=true may have skipped the release; only upload if it exists
             if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
               gh release upload "$tag" \
-                "${tgz}.sig" "${tgz}.pem" \
+                "${tgz}.bundle" \
                 --repo "$GITHUB_REPOSITORY" --clobber
             fi
           done

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ghcr.io/maksimrudakov/charts/alertly:0.7.0
 
-# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.7.0 release)
+# .tgz from GitHub Release (download the .tgz and .tgz.bundle from the alertly-0.7.0 release)
 cosign verify-blob \
-  --certificate alertly-0.7.0.tgz.pem \
-  --signature alertly-0.7.0.tgz.sig \
+  --bundle alertly-0.7.0.tgz.bundle \
+  --new-bundle-format \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   alertly-0.7.0.tgz


### PR DESCRIPTION
## Проблема

Релиз `v0.7.0` упал в job `chart-release`:

```
Error: signing /tmp/alertly-0.7.0.tgz: create bundle file: open : no such file or directory
```

Dependabot (#31) поднял `sigstore/cosign-installer` v3.10.1 → v4.1.2, который ставит cosign **v3.0.6**. В cosign v3 `sign-blob` по умолчанию пишет Sigstore-bundle: `--output-signature` / `--output-certificate` стали no-op'ами, а пустой путь бандла обрывает подпись.

CI на PR был зелёный — шаг выполняется только на теге.

## Что сделано

- `sign-blob` переведён на `--new-bundle-format --bundle "${tgz}.bundle"`, в GitHub Release заливается `.bundle` вместо `.sig`/`.pem`.
- README: секция «Verify signatures» приведена к тому же контракту (`cosign verify-blob --bundle ... --new-bundle-format`).

## Последствия для v0.7.0

Прошли: goreleaser, docker (образ подписан), chart-releaser (`alertly-0.7.0.tgz` + gh-pages index).
Не прошли: подпись чарта и push чарта в OCI ghcr — в ghcr до сих пор `0.6.0`.

После мержа нужен релиз `v0.7.1` (chart 0.7.1) — перезапуск упавшего job'а взял бы код с тега и упал бы снова.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqEqnTjXAoPgtEz6F6nkPC