### PR TITLE
ci: fix chart signing under cosign 3.x (keep legacy .sig/.pem outputs)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,7 +135,13 @@ jobs:
             tag="${name}-${version}"
             tgz="/tmp/${tag}.tgz"
             helm package "$chart" -d /tmp
+            # cosign 3.x (cosign-installer v4) defaults to the new bundle format
+            # and ignores --output-signature/--output-certificate, failing with
+            # "create bundle file: open : no such file or directory". Keep the
+            # legacy .sig/.pem outputs (documented in the README verify steps)
+            # by opting out explicitly.
             cosign sign-blob --yes \
+              --new-bundle-format=false \
               --output-signature "${tgz}.sig" \
               --output-certificate "${tgz}.pem" \
               "${tgz}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Fixed
+- Release workflow: chart tarball signing under cosign 3.x (`cosign-installer` v4) — the new default bundle format ignores `--output-signature`/`--output-certificate` and aborted the `chart-release` job; the step now opts out via `--new-bundle-format=false`, keeping the documented `.sig`/`.pem` artifacts.
+
 ## [0.7.0] - 2026-08-28
 
 Hardening release: the Telegram delivery path loses three long-standing bugs (token in logs, a retry-deadline mechanism that never fired, message splitting Telegram could reject), every in-memory registry and API call gains a bound, and webhooks get an optional chat allowlist. Backward compatible: every new knob defaults to previous behaviour except the 100-alert payload cap (mirrors the generic source) and tightened HTTP header/timeout defaults.


### PR DESCRIPTION
## Summary

The v0.7.0 Release run ([33146413288](https://github.com/MaksimRudakov/alertly/actions/runs/33146413288)) failed in exactly the spot flagged as untested when #31 merged: `cosign-installer` v4 installs **cosign 3.x**, whose new default bundle format ignores `--output-signature`/`--output-certificate` and aborts with:

```
Error: signing /tmp/alertly-0.7.0.tgz: create bundle file: open : no such file or directory
```

Only the `chart-release` job failed (3 of 4 jobs green: goreleaser binaries + GitHub Release, container image, image signing). The chart tarball signing step now passes `--new-bundle-format=false`, keeping the legacy `.sig`/`.pem` artifacts that the README's `cosign verify-blob --certificate … --signature …` instructions document. Recorded under `[Unreleased]` in the CHANGELOG.

Re-runs of the failed job would still use the workflow file at the tag's commit, so after this merges the `v0.7.0` tag needs to be re-pointed at the fix commit to produce signed chart artifacts (steps in the PR conversation / session).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore
- [x] CI / build

## Checklist

- [x] `make lint` passes — workflow-only change; YAML validated locally
- [x] `make test` passes (with `-race`) — no Go changes
- [x] Tests added or updated for behavior changes — n/a (CI config)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No secrets, tokens, or PII in diff


---
_Generated by [Claude Code](https://claude.ai/code/session_01SxyS3gJnAyqLGnRGswpani)_