### PR TITLE
chore(release): v0.7.1 (chart 0.7.1, appVersion 0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-28
+
+Re-release of 0.7.0: the runtime is byte-for-byte identical, only the release pipeline is fixed. The v0.7.0 tag run failed while signing the chart tarball, so that release shipped without a chart signature and without the OCI chart in ghcr — use 0.7.1 instead.
+
 ### Fixed
 - Release workflow: chart tarball signing under cosign 3.x (`cosign-installer` v4) — the new default bundle format ignores `--output-signature`/`--output-certificate` and aborted the `chart-release` job; the step now opts out via `--new-bundle-format=false`, keeping the documented `.sig`/`.pem` artifacts.
 
@@ -163,7 +167,8 @@ Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to kee
 - Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
 - New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/MaksimRudakov/alertly/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/MaksimRudakov/alertly/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/MaksimRudakov/alertly/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/MaksimRudakov/alertly/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ helm search repo alertly
 OCI (GitHub Container Registry, no `helm repo add` needed):
 
 ```bash
-helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.7.0
+helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.7.1
 ```
 
 ### Install
@@ -66,7 +66,7 @@ Quick install with tokens passed directly (fine for a lab / personal cluster —
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.0 \
+  --version 0.7.1 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -76,7 +76,7 @@ Or from OCI:
 ```bash
 helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.0 \
+  --version 0.7.1 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -102,7 +102,7 @@ Then install referencing it:
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.0 \
+  --version 0.7.1 \
   --set secret.create=false \
   --set secret.existingSecret=alertly-tokens \
   --set reloader.enabled=true   # optional: auto-restart on Secret/ConfigMap changes
@@ -119,15 +119,15 @@ Both the chart tarball (attached to the GitHub Release) and the OCI chart manife
 cosign verify \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/maksimrudakov/charts/alertly:0.7.0
+  ghcr.io/maksimrudakov/charts/alertly:0.7.1
 
-# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.7.0 release)
+# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.7.1 release)
 cosign verify-blob \
-  --certificate alertly-0.7.0.tgz.pem \
-  --signature alertly-0.7.0.tgz.sig \
+  --certificate alertly-0.7.1.tgz.pem \
+  --signature alertly-0.7.1.tgz.sig \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  alertly-0.7.0.tgz
+  alertly-0.7.1.tgz
 ```
 
 The container image `ghcr.io/maksimrudakov/alertly` is signed the same way.

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.7.1
+appVersion: "0.7.1"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 

--- a/examples/values-production.yaml
+++ b/examples/values-production.yaml
@@ -3,7 +3,7 @@
 # Install:
 #   helm install alertly alertly/alertly \
 #     --namespace monitoring-system --create-namespace \
-#     --version 0.7.0 \
+#     --version 0.7.1 \
 #     -f examples/values-production.yaml
 #
 # Prerequisites:


### PR DESCRIPTION
Re-release 0.7.0 — код не менялся, только версии и CHANGELOG.

## Зачем

Тег `v0.7.0` упал в job `chart-release` на подписи чарта (cosign 3.x из `cosign-installer` v4). Итог: релиз `alertly-0.7.0` без `.sig`/`.pem`, а шаг push чарта в OCI не выполнился — в ghcr до сих пор `0.6.0`. Фикс подписи влит в #35, но перезапуск не помогает: тег берёт свой код. Нужен новый тег.

## Изменения

- `charts/alertly/Chart.yaml`: version/appVersion 0.7.0 → 0.7.1
- README, `charts/alertly/README.md`, `examples/values-production.yaml`: ссылки на версию
- CHANGELOG: секция `[0.7.1]` (запись про фикс подписи перенесена из Unreleased)

## После мержа

```bash
git checkout main && git pull
git tag -a v0.7.1 -m "v0.7.1" && git push origin v0.7.1
```

Проверить, что зелёные все 4 job'а Release, что в релизе `alertly-0.7.1` лежат `.tgz`/`.sig`/`.pem` и что в ghcr появился `charts/alertly:0.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqEqnTjXAoPgtEz6F6nkPC