### PR TITLE
fix(ci): sign chart tarballs as Sigstore bundles; release v0.7.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,20 +135,20 @@ jobs:
             tag="${name}-${version}"
             tgz="/tmp/${tag}.tgz"
             helm package "$chart" -d /tmp
-            # cosign 3.x (cosign-installer v4) defaults to the new bundle format
-            # and ignores --output-signature/--output-certificate, failing with
-            # "create bundle file: open : no such file or directory". Keep the
-            # legacy .sig/.pem outputs (documented in the README verify steps)
-            # by opting out explicitly.
+            # cosign 3.x (cosign-installer v4) signs keyless through a signing
+            # config and refuses the legacy .sig/.pem outputs there: without a
+            # bundle it fails with "must provide --new-bundle-format or --bundle
+            # where applicable with --signing-config or --use-signing-config"
+            # (and with an empty --bundle path, "create bundle file: open :").
+            # The Sigstore bundle carries both the signature and the certificate.
             cosign sign-blob --yes \
-              --new-bundle-format=false \
-              --output-signature "${tgz}.sig" \
-              --output-certificate "${tgz}.pem" \
+              --new-bundle-format \
+              --bundle "${tgz}.bundle" \
               "${tgz}"
             # skip_existing=true may have skipped the release; only upload if it exists
             if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
               gh release upload "$tag" \
-                "${tgz}.sig" "${tgz}.pem" \
+                "${tgz}.bundle" \
                 --repo "$GITHUB_REPOSITORY" --clobber
             fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-28
+
+Second re-release attempt of 0.7.0 — runtime unchanged again. 0.7.1 still failed to publish its chart signature and OCI chart: opting out of the new bundle format is not possible under cosign 3.x keyless signing (`must provide --new-bundle-format or --bundle ... with --signing-config`).
+
+### Changed
+- **Chart tarball signatures are now Sigstore bundles.** The GitHub Release carries a single `alertly-<version>.tgz.bundle` asset instead of the previous `.tgz.sig` + `.tgz.pem` pair; verify with `cosign verify-blob --bundle alertly-<version>.tgz.bundle --new-bundle-format ...` (see README). Image and OCI chart signatures are unaffected.
+
 ## [0.7.1] - 2026-08-28
 
 Re-release of 0.7.0: the runtime is byte-for-byte identical, only the release pipeline is fixed. The v0.7.0 tag run failed while signing the chart tarball, so that release shipped without a chart signature and without the OCI chart in ghcr — use 0.7.1 instead.
@@ -167,7 +174,8 @@ Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to kee
 - Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
 - New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/MaksimRudakov/alertly/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/MaksimRudakov/alertly/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/MaksimRudakov/alertly/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/MaksimRudakov/alertly/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ helm search repo alertly
 OCI (GitHub Container Registry, no `helm repo add` needed):
 
 ```bash
-helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.7.1
+helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.7.2
 ```
 
 ### Install
@@ -66,7 +66,7 @@ Quick install with tokens passed directly (fine for a lab / personal cluster —
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.1 \
+  --version 0.7.2 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -76,7 +76,7 @@ Or from OCI:
 ```bash
 helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.1 \
+  --version 0.7.2 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -102,7 +102,7 @@ Then install referencing it:
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.1 \
+  --version 0.7.2 \
   --set secret.create=false \
   --set secret.existingSecret=alertly-tokens \
   --set reloader.enabled=true   # optional: auto-restart on Secret/ConfigMap changes
@@ -119,15 +119,15 @@ Both the chart tarball (attached to the GitHub Release) and the OCI chart manife
 cosign verify \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/maksimrudakov/charts/alertly:0.7.1
+  ghcr.io/maksimrudakov/charts/alertly:0.7.2
 
-# .tgz from GitHub Release (download the .tgz, .sig, .pem from the alertly-0.7.1 release)
+# .tgz from GitHub Release (download the .tgz and .tgz.bundle from the alertly-0.7.2 release)
 cosign verify-blob \
-  --certificate alertly-0.7.1.tgz.pem \
-  --signature alertly-0.7.1.tgz.sig \
+  --bundle alertly-0.7.2.tgz.bundle \
+  --new-bundle-format \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  alertly-0.7.1.tgz
+  alertly-0.7.2.tgz
 ```
 
 The container image `ghcr.io/maksimrudakov/alertly` is signed the same way.

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.7.2
+appVersion: "0.7.2"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 

--- a/examples/values-production.yaml
+++ b/examples/values-production.yaml
@@ -3,7 +3,7 @@
 # Install:
 #   helm install alertly alertly/alertly \
 #     --namespace monitoring-system --create-namespace \
-#     --version 0.7.1 \
+#     --version 0.7.2 \
 #     -f examples/values-production.yaml
 #
 # Prerequisites:


### PR DESCRIPTION
## Проблема

Фикс #35 не сработал — тег `v0.7.1` упал на том же шаге `Sign chart tarballs`, но с новой ошибкой:

```
Error: must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config
```

В cosign 3.x keyless-подпись идёт через signing config, и legacy `.sig`/`.pem` там недоступны в принципе: `--new-bundle-format=false` отвергается. Единственный рабочий путь — `--bundle` (на него же указывают deprecation-warning'и обоих старых флагов).

## Изменения

- `release.yaml`: `cosign sign-blob --new-bundle-format --bundle "${tgz}.bundle"`, в Release заливается один `alertly-<version>.tgz.bundle` вместо пары `.sig`/`.pem`. Подпись образа и OCI-чарта (`cosign sign`) не затронуты — они и так проходят.
- README: verify-blob через `--bundle ... --new-bundle-format`.
- CHANGELOG: секция `[0.7.2]` с пометкой о смене формата подписи чарта.
- Версии 0.7.1 → 0.7.2 (фикс работает только на новом теге).

## Состояние релизов

`v0.7.0` и `v0.7.1`: бинарники, образ и `helm repo` (gh-pages) опубликованы; подписи чарта нет, в ghcr OCI-чарт остался на `0.6.0`. Закрывается тегом `v0.7.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqEqnTjXAoPgtEz6F6nkPC