### PR TITLE
fix: clear send-failure unreadiness on a successful getMe probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Fixed
+- **A send-failure readiness window no longer locks the pod out permanently.** Ten consecutive server/network errors on the send path flip readiness off (`telegram api: too many consecutive 5xx errors`); until now only `RecordSendSuccess` could clear that, and a successful `getMe` probe was ignored because it only re-armed *probe-driven* unreadiness. That was self-locking: unready removes the pod from the Service endpoints, so Alertmanager cannot deliver a webhook, so no send can succeed — observed in a live cluster as a pod sitting unready for four days after a transient Telegram outage, with `getMe` succeeding every minute the whole time. A successful probe now clears unreadiness whoever set it.
+
 ## [0.7.2] - 2026-08-28
 
 Second re-release attempt of 0.7.0 — runtime unchanged again. 0.7.1 still failed to publish its chart signature and OCI chart: opting out of the new bundle format is not possible under cosign 3.x keyless signing (`must provide --new-bundle-format or --bundle ... with --signing-config`).

--- a/cmd/alertly/main.go
+++ b/cmd/alertly/main.go
@@ -341,7 +341,6 @@ func telegramHealthLoop(ctx context.Context, c telegram.Client, r server.Readine
 	backoff := time.Second
 	consecFails := 0
 	everReady := false
-	probeUnready := true // startup counts as probe-driven unreadiness
 
 	for {
 		callCtx, cancel := context.WithTimeout(ctx, probeTimeout)
@@ -354,10 +353,16 @@ func telegramHealthLoop(ctx context.Context, c telegram.Client, r server.Readine
 
 		var wait time.Duration
 		if err == nil {
-			if probeUnready {
+			// A successful probe clears unreadiness whoever set it. Restricting
+			// this to probe-driven unreadiness made the send-failure window
+			// self-locking: RecordSendFailure flips the pod unready, the pod
+			// leaves the Service endpoints, no webhook can arrive, so no send
+			// can succeed — and only RecordSendSuccess would have cleared it.
+			// The probe exercises the very API the failed sends went to, so its
+			// success is sufficient evidence the path is usable again.
+			if ready, _ := r.IsReady(); !ready {
 				logger.Info("telegram getMe ok; readiness=ready")
 				r.MarkReady()
-				probeUnready = false
 			}
 			everReady = true
 			consecFails = 0
@@ -372,7 +377,6 @@ func telegramHealthLoop(ctx context.Context, c telegram.Client, r server.Readine
 			)
 			if !everReady || consecFails >= failureThreshold {
 				r.MarkUnready("telegram getMe failed: " + err.Error())
-				probeUnready = true
 			}
 			wait = backoff
 			if backoff < maxBackoff {

--- a/cmd/alertly/main_test.go
+++ b/cmd/alertly/main_test.go
@@ -85,3 +85,37 @@ func TestTelegramHealthLoop_StartupAndRecovery(t *testing.T) {
 		t.Fatal("health loop did not exit on ctx cancel")
 	}
 }
+
+// A send-failure window must not outlive the outage that caused it: once getMe
+// succeeds again the pod has to become ready even though no send has succeeded
+// since. Without this the state is self-locking — unready drops the pod from
+// the Service endpoints, so no webhook arrives and RecordSendSuccess (the only
+// other way out) can never fire.
+func TestTelegramHealthLoop_ClearsSendFailureUnreadiness(t *testing.T) {
+	fake := &fakeTelegram{}
+	readiness := server.NewReadiness()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go telegramHealthLoop(ctx, fake, readiness, logger, 20*time.Millisecond)
+
+	waitFor(t, 2*time.Second, func() bool {
+		ready, _ := readiness.IsReady()
+		return ready
+	}, "readiness never became ready while getMe succeeded")
+
+	// Telegram goes down for outbound sends only: the send path records enough
+	// server errors to trip the window, while getMe keeps succeeding.
+	for i := 0; i < 10; i++ {
+		readiness.RecordSendFailure(true)
+	}
+	if ready, reason := readiness.IsReady(); ready {
+		t.Fatalf("send-failure window did not flip readiness: reason=%q", reason)
+	}
+
+	waitFor(t, 5*time.Second, func() bool {
+		ready, _ := readiness.IsReady()
+		return ready
+	}, "readiness stayed unready although getMe kept succeeding (send-failure deadlock)")
+}


### PR DESCRIPTION
## Symptom

A pod can sit `Ready=False` indefinitely — for days — while Alertmanager reports `AlertmanagerFailedToSendAlerts` at 100%:

```
$ curl -s http://<pod>:8080/readyz
{"telegram_api":"failed","reason":"telegram api: too many consecutive 5xx errors","last_check":"<now>"}
```

Meanwhile `getMe` succeeds every minute (`last_check` keeps advancing, no `telegram getMe failed` in the logs), the Telegram API is reachable from the cluster, and the process never restarts. Only a manual `rollout restart` brings it back.

## Cause

`RecordSendFailure` flips readiness off after 10 consecutive server or network errors on the send path. Only `RecordSendSuccess` could clear that: `telegramHealthLoop` called `MarkReady()` solely when it had set the unreadiness itself (`probeUnready`), so a succeeding probe left a send-failure window untouched.

The combination is self-locking:

```
10 network errors on sends  ->  unready
unready                     ->  pod drops out of the Service endpoints
no endpoints                ->  Alertmanager cannot deliver a webhook
no webhooks                 ->  nothing is ever sent
nothing sent                ->  RecordSendSuccess never runs
```

A transient Telegram outage is enough to trip it, and the state outlives the outage that caused it by an unbounded margin.

Not a recent regression: `RecordSendFailure` dates back to the initial commit, and the probe-driven vs send-driven split to 0.3.0. Before 0.3.0 it was worse still — the health loop returned after its first success and never probed again.

## Change

A successful `getMe` probe now clears unreadiness whoever set it. The probe hits the same API the failed sends went to, so its success is sufficient evidence the path is usable again. `probeUnready` is gone — `IsReady()` already carries the state the branch needs.

Degradation behaviour is unchanged: three consecutive probe failures still flip the pod unready, and `RecordSendFailure` still opens the window after 10 send errors. Only the way out of that state changes.

## Test

`TestTelegramHealthLoop_ClearsSendFailureUnreadiness` reproduces the scenario: `getMe` succeeds throughout, the window is opened via `RecordSendFailure`, and readiness must return. Against the unfixed loop it fails:

```
main_test.go:117: readiness stayed unready although getMe kept succeeding (send-failure deadlock)
FAIL
```

`go test -race -count=1 ./...`, `go vet ./...` and `gofmt` are clean.

## Note for operators

Every deployment running 0.7.x is exposed. Until this ships, recovery is manual:

```bash
kubectl -n <namespace> rollout restart deploy/alertly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqEqnTjXAoPgtEz6F6nkPC
