### PR TITLE
chore(release): v0.7.3 (chart 0.7.3, appVersion 0.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-09-04
+
+A single-fix release: a pod that hit the send-failure readiness window could stay unready forever, taking the whole webhook path down until someone restarted it by hand. Anyone running 0.7.x should upgrade.
+
 ### Fixed
 - **A send-failure readiness window no longer locks the pod out permanently.** Ten consecutive server/network errors on the send path flip readiness off (`telegram api: too many consecutive 5xx errors`); until now only `RecordSendSuccess` could clear that, and a successful `getMe` probe was ignored because it only re-armed *probe-driven* unreadiness. That was self-locking: unready removes the pod from the Service endpoints, so Alertmanager cannot deliver a webhook, so no send can succeed — observed in a live cluster as a pod sitting unready for four days after a transient Telegram outage, with `getMe` succeeding every minute the whole time. A successful probe now clears unreadiness whoever set it.
 
@@ -177,7 +181,8 @@ Runtime behaviour unchanged vs `v0.0.2`. This release bumps the image tag to kee
 - Helm chart `charts/alertly` (version 0.0.1, appVersion 0.0.1): Deployment/Service/ConfigMap/Secret/ServiceAccount/Ingress (opt-in) + `extraManifests` escape hatch for PodMonitor/PDB/NetworkPolicy. Published to GitHub Pages (`helm repo add`) and OCI (`oci://ghcr.io/maksimrudakov/charts`). Both tarball and OCI manifest cosign-signed.
 - New alertmanager template: `Alert Name`, `Severity`, `Runbook URL` formatting; `generatorURL` is no longer emitted.
 
-[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/MaksimRudakov/alertly/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/MaksimRudakov/alertly/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/MaksimRudakov/alertly/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/MaksimRudakov/alertly/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/MaksimRudakov/alertly/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ helm search repo alertly
 OCI (GitHub Container Registry, no `helm repo add` needed):
 
 ```bash
-helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.7.2
+helm show chart oci://ghcr.io/maksimrudakov/charts/alertly --version 0.7.3
 ```
 
 ### Install
@@ -66,7 +66,7 @@ Quick install with tokens passed directly (fine for a lab / personal cluster —
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.2 \
+  --version 0.7.3 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -76,7 +76,7 @@ Or from OCI:
 ```bash
 helm install alertly oci://ghcr.io/maksimrudakov/charts/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.2 \
+  --version 0.7.3 \
   --set secret.values.telegramBotToken=<TOKEN> \
   --set secret.values.webhookAuthToken=<TOKEN>
 ```
@@ -102,7 +102,7 @@ Then install referencing it:
 ```bash
 helm install alertly alertly/alertly \
   --namespace monitoring-system --create-namespace \
-  --version 0.7.2 \
+  --version 0.7.3 \
   --set secret.create=false \
   --set secret.existingSecret=alertly-tokens \
   --set reloader.enabled=true   # optional: auto-restart on Secret/ConfigMap changes
@@ -119,15 +119,15 @@ Both the chart tarball (attached to the GitHub Release) and the OCI chart manife
 cosign verify \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/maksimrudakov/charts/alertly:0.7.2
+  ghcr.io/maksimrudakov/charts/alertly:0.7.3
 
-# .tgz from GitHub Release (download the .tgz and .tgz.bundle from the alertly-0.7.2 release)
+# .tgz from GitHub Release (download the .tgz and .tgz.bundle from the alertly-0.7.3 release)
 cosign verify-blob \
-  --bundle alertly-0.7.2.tgz.bundle \
+  --bundle alertly-0.7.3.tgz.bundle \
   --new-bundle-format \
   --certificate-identity-regexp "https://github.com/MaksimRudakov/alertly/.github/workflows/release.yaml@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  alertly-0.7.2.tgz
+  alertly-0.7.3.tgz
 ```
 
 The container image `ghcr.io/maksimrudakov/alertly` is signed the same way.

--- a/charts/alertly/Chart.yaml
+++ b/charts/alertly/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: alertly
 description: Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 type: application
-version: 0.7.2
-appVersion: "0.7.2"
+version: 0.7.3
+appVersion: "0.7.3"
 home: https://github.com/MaksimRudakov/alertly
 sources:
   - https://github.com/MaksimRudakov/alertly

--- a/charts/alertly/README.md
+++ b/charts/alertly/README.md
@@ -1,6 +1,6 @@
 # alertly
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.3](https://img.shields.io/badge/AppVersion-0.7.3-informational?style=flat-square)
 
 Webhook-to-Telegram bridge for Alertmanager and Kubewatch
 

--- a/examples/values-production.yaml
+++ b/examples/values-production.yaml
@@ -3,7 +3,7 @@
 # Install:
 #   helm install alertly alertly/alertly \
 #     --namespace monitoring-system --create-namespace \
-#     --version 0.7.2 \
+#     --version 0.7.3 \
 #     -f examples/values-production.yaml
 #
 # Prerequisites:


### PR DESCRIPTION
Patch release carrying the readiness fix from #40. No code changes beyond that; versions and CHANGELOG only.

## Why now

The bug strands a pod outside the Service endpoints after any transient Telegram outage long enough to trip the send-failure window, and nothing short of a manual `rollout restart` brings it back. Every 0.7.x deployment is exposed, so this should not wait for the next feature release.

## Changes

- `charts/alertly/Chart.yaml`: version and appVersion 0.7.2 -> 0.7.3
- README, `charts/alertly/README.md`, `examples/values-production.yaml`: version references
- CHANGELOG: `[0.7.3]` section

## After merge

```bash
git checkout main && git pull
git tag -a v0.7.3 -m "v0.7.3" && git push origin v0.7.3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqEqnTjXAoPgtEz6F6nkPC
